### PR TITLE
use js-yaml replace yaml, add forceQuotes when stringify yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -612,6 +612,12 @@
         "@types/node": "*"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -2790,7 +2796,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       },
@@ -2798,8 +2803,7 @@
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         }
       }
     },
@@ -4664,11 +4668,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "dotenv": "^8.2.0",
     "envfile": "^6.14.0",
     "fs-extra": "^9.1.0",
+    "js-yaml": "^4.1.0",
     "memory-streams": "^0.1.3",
     "prompts": "^2.4.0",
     "string-format": "^2.0.0",
     "winston": "^3.3.3",
-    "yaml": "^1.10.0",
     "yargs": "^16.0.0"
   },
   "devDependencies": {
@@ -56,6 +56,7 @@
     "@types/axios": "^0.14.0",
     "@types/dockerode": "^3.2.1",
     "@types/fs-extra": "^9.0.9",
+    "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.6.4",
     "@types/prompts": "^2.0.9",

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs-extra'
-import YAML from 'yaml'
+import YAML from 'js-yaml'
 import { parse, stringify } from 'envfile'
 import CryptoConfigYaml from '../model/yaml/network/cryptoConfigYaml'
 import ConnectionConfigYaml from '../model/yaml/network/connectionConfigYaml'
@@ -12,6 +12,7 @@ import CaDockerComposeYaml from '../model/yaml/docker-compose/caComposeYaml'
 import { OrgJsonType } from '../model/type/org.type'
 import { ProcessError } from '../util'
 import { Config } from '../config'
+import { DockerComposeYamlInterface } from '../model/yaml/docker-compose/dockerComposeYaml'
 
 export enum InstanceTypeEnum {
   ca = 'ca',
@@ -157,8 +158,8 @@ export default class BdkFile {
     fs.writeFileSync(this.getDockerComposeYamlPath(hostName, type), dockerComposeYaml.getYamlString())
   }
 
-  public getDockerComposeYaml (hostName: string, type: InstanceTypeEnum) {
-    return YAML.parse(fs.readFileSync(this.getDockerComposeYamlPath(hostName, type)).toString())
+  public getDockerComposeYaml (hostName: string, type: InstanceTypeEnum): DockerComposeYamlInterface {
+    return YAML.load(fs.readFileSync(this.getDockerComposeYamlPath(hostName, type)).toString()) as DockerComposeYamlInterface
   }
 
   public createOrgConfigEnv (address: string, dotEnv: string) {

--- a/src/instance/infra/docker/runner.ts
+++ b/src/instance/infra/docker/runner.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import YAML from 'yaml'
+import YAML from 'js-yaml'
 import { WritableStream } from 'memory-streams'
 import { spawnSync } from 'child_process'
 import Dockerode from 'dockerode'
@@ -8,6 +8,7 @@ import { DockerCreateOptionsType, DockerStartOptionsType, DockerRunCommandType }
 import config from '../../../config'
 import { DockerError, FabricContainerError } from '../../../util/error'
 import { DockerResultType, InfraRunner } from '../InfraRunner.interface'
+import { DockerComposeYamlInterface } from '../../../model/yaml/docker-compose/dockerComposeYaml'
 
 export class Runner implements InfraRunner<DockerResultType> {
   private dockerode: Dockerode
@@ -84,7 +85,7 @@ export class Runner implements InfraRunner<DockerResultType> {
   }
 
   public upInBackground = async (dockerComposeFile: string) => {
-    const networks = YAML.parse(fs.readFileSync(dockerComposeFile).toString()).networks
+    const networks = (YAML.load(fs.readFileSync(dockerComposeFile).toString()) as DockerComposeYamlInterface).networks
     for (const network in networks) {
       if (networks[network]?.external) {
         await this.checkAndCreateNetwork(network)

--- a/src/model/yaml/bdkYaml.ts
+++ b/src/model/yaml/bdkYaml.ts
@@ -1,4 +1,4 @@
-import YAML from 'yaml'
+import YAML from 'js-yaml'
 
 class BdkYaml<T> {
   public value: T
@@ -8,7 +8,7 @@ class BdkYaml<T> {
   }
 
   public getYamlString () {
-    return YAML.stringify(this.value)
+    return YAML.dump(this.value, { forceQuotes: true })
   }
 
   public getJsonString () {

--- a/src/model/yaml/docker-compose/dockerComposeYaml.ts
+++ b/src/model/yaml/docker-compose/dockerComposeYaml.ts
@@ -49,7 +49,7 @@ interface NetworkInterface {
   name?: string
 }
 
-interface DockerComposeYamlInterface {
+export interface DockerComposeYamlInterface {
   version: string
   services: {
     [serviceName: string]: ServiceInterface


### PR DESCRIPTION
# PULL REQUEST

## 說明 (Description)

`yaml.stringify` 會將 `"user": "502:20"` 輸出成 `user: 502:20`
mac的docker-compose讀到 `user: 502:20` 會報錯
```
ERROR: The Compose file '/Users/xxx/.bdk/bdk-network/docker-compose/docker-compose-ca-rca.xxxxxxx.com.yaml' is invalid because:
services.rca.xxxxxxx.com.user contains an invalid type, it should be a string
```
改用 `js-yaml` 套件提供之 `dump` ，可傳入`forceQuotes: true`


## 相關問題 (Linked Issues)
- #(issue1)
- #(issue2)
- #(issue3)

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [ ] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS: Mac
* NodeJS Version:
* NPM Version:
* Docker Version:

## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [x] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [ ] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [x] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [x] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [ ] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [x] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
