### PR TITLE
replace 'config-yaml/configtxOrgs.json' with 'config-yaml/orgs/[peer/orderer]-[orgName].json

### DIFF
--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -205,17 +205,17 @@ export default class BdkFile {
     fs.mkdirSync(`${this.bdkPath}/chaincode`, { recursive: true })
   }
 
-  public createOrgConfigJson (name: string, orgJson: string) {
+  public createOrgDefinitionJson (name: string, orgJson: string) {
     fs.mkdirSync(`${this.bdkPath}/org-json`, { recursive: true })
     fs.writeFileSync(`${this.bdkPath}/org-json/${name}.json`, orgJson)
   }
 
-  public createOrdererOrgConsenter (name: string, consenterJson: string) {
+  public createOrdererOrgConsenterJson (name: string, consenterJson: string) {
     fs.mkdirSync(`${this.bdkPath}/org-json`, { recursive: true })
     fs.writeFileSync(`${this.bdkPath}/org-json/${name}-consenter.json`, consenterJson)
   }
 
-  public createExportOrgConfigJson (exportOrgJson: OrgJsonType, file: string) {
+  public createExportOrgDefinitionJson (exportOrgJson: OrgJsonType, file: string) {
     const splitFilePath = file.split('/', 3)
     for (let i = 0; i < splitFilePath.length - 1; i++) {
       fs.mkdirSync(`${splitFilePath[i]}`, { recursive: true })

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -105,10 +105,12 @@ export default class BdkFile {
       peerOrgs: {},
     }
     fs.readdirSync(`${this.bdkPath}/config-yaml/orgs`).forEach((filename: string) => {
-      if (/^orderer-.*\.json$/.test(filename)) {
-        configtxOrgs.ordererOrgs[filename.replace(/^orderer-/, '').replace(/\.json$/, '')] = JSON.parse(fs.readFileSync(`${this.bdkPath}/config-yaml/orgs/${filename}`).toString())
-      } else if (/^peer-.*\.json$/.test(filename)) {
-        configtxOrgs.peerOrgs[filename.replace(/^peer-/, '').replace(/\.json$/, '')] = JSON.parse(fs.readFileSync(`${this.bdkPath}/config-yaml/orgs/${filename}`).toString())
+      const peerOrg = filename.match(/(?<=^peer-).*(?=\.json$)/)?.[0]
+      const ordererOrg = filename.match(/(?<=^orderer-).*(?=\.json$)/)?.[0]
+      if (ordererOrg) {
+        configtxOrgs.ordererOrgs[ordererOrg] = JSON.parse(fs.readFileSync(`${this.bdkPath}/config-yaml/orgs/${filename}`).toString())
+      } else if (peerOrg) {
+        configtxOrgs.peerOrgs[peerOrg] = JSON.parse(fs.readFileSync(`${this.bdkPath}/config-yaml/orgs/${filename}`).toString())
       }
     },
     )

--- a/src/instance/fabricTools.ts
+++ b/src/instance/fabricTools.ts
@@ -126,7 +126,7 @@ export default class FabricTools extends AbstractInstance {
     options)
   }
 
-  public async createNewOrgConfigTx (orgName: string, options?: OptionsType): Promise<DockerResultType> {
+  public async printOrgDefinitionJson (orgName: string, options?: OptionsType): Promise<DockerResultType> {
     const result = await this.infraRunCommand([
       'configtxgen',
       '-printOrg', `${orgName}`,

--- a/src/model/prompts/util.ts
+++ b/src/model/prompts/util.ts
@@ -67,7 +67,12 @@ export const getChannelList = (config: Config): string[] => {
 export const getOrgNames = (config: Config): string[] => {
   try {
     const hostBasePath = `${config.infraConfig.bdkPath}/${config.networkName}`
-    return fs.readdirSync(`${hostBasePath}/config-yaml/orgs`).filter(x => /^peer-.*\.json$/.test(x)).map(x => x.replace(/^peer-/, '').replace(/\.json$/, ''))
+    const orgs: string[] = []
+    fs.readdirSync(`${hostBasePath}/config-yaml/orgs`).forEach(fileName => {
+      const org = fileName.match(/(?<=^peer-).*(?=\.json$)/)?.[0]
+      org && orgs.push(org)
+    })
+    return orgs
   } catch {
     return []
   }

--- a/src/model/yaml/network/configtx.ts
+++ b/src/model/yaml/network/configtx.ts
@@ -16,7 +16,7 @@ interface OrganizationInterface {
   ID: string // ID to load the MSP definition as
   MSPDir: string // MSPDir is the filesystem path which contains the MSP configuration
 }
-interface OrdererOrganizationInterface extends OrganizationInterface {
+export interface OrdererOrganizationInterface extends OrganizationInterface {
   Policies: { // Policies defines the set of policies at this level of the config tree. For organization policies, their canonical path is usually /Channel/<Application|Orderer>/<OrgName>/<PolicyName>
     Readers: PolicyInterface
     Writers: PolicyInterface
@@ -24,7 +24,7 @@ interface OrdererOrganizationInterface extends OrganizationInterface {
   }
   OrdererEndpoints: string[]
 }
-interface PeerOrganizationInterface extends OrganizationInterface {
+export interface PeerOrganizationInterface extends OrganizationInterface {
   Policies: { // Policies defines the set of policies at this level of the config tree. For organization policies, their canonical path is usually /Channel/<Application|Orderer>/<OrgName>/<PolicyName>
     Readers: PolicyInterface
     Writers: PolicyInterface
@@ -270,6 +270,7 @@ class ConfigtxYaml extends BdkYaml<ConfigtxInterface> {
 
     this.ordererOrgs[payload.name] = newOrdererOrg
     this.value.Organizations.push(newOrdererOrg)
+    return newOrdererOrg
   }
 
   public addPeerOrg (payload: { name: string; mspDir: string; domain: string; anchorPeers: {hostname: string; port?: number}[]}) {
@@ -281,7 +282,7 @@ class ConfigtxYaml extends BdkYaml<ConfigtxInterface> {
     // ports -> [7051, 7151]
     const newPeerOrg: PeerOrganizationInterface = {
       Name: payload.name,
-      ID: `${payload.name}`,
+      ID: payload.name,
       MSPDir: payload.mspDir,
       Policies: {
         Readers: {
@@ -306,6 +307,7 @@ class ConfigtxYaml extends BdkYaml<ConfigtxInterface> {
 
     this.peerOrgs[payload.name] = newPeerOrg
     this.value.Organizations.push(newPeerOrg)
+    return newPeerOrg
   }
 
   public addSystemChannelProfile (payload: { name: string; etcdRaftConsenters: EtcdRaftConsentersInterface[]; ordererOrgs: string[]; consortiums: { [cousortiumName: string]: string[] }; batchTimeout?: string; BatchSize?: BatchSizeInterface }) {
@@ -371,11 +373,6 @@ class ConfigtxYaml extends BdkYaml<ConfigtxInterface> {
     if ('Application' in profile) {
       profile.Application.Policies[payload.policyKey] = payload.policy
     }
-  }
-
-  public exportOrgs () {
-    const configtxOrgs: ConfigtxOrgs = { ordererOrgs: this.ordererOrgs, peerOrgs: this.peerOrgs }
-    return configtxOrgs
   }
 
   public importOrgs (data: ConfigtxOrgs) {

--- a/src/service/channel.ts
+++ b/src/service/channel.ts
@@ -273,20 +273,6 @@ export default class Channel extends AbstractService {
   }
 
   /**
-   * @description 由 config.yaml 建立 peer org 的 json 檔案
-   * @param orgName - peer org 的名稱
-   * @returns 在 blockchain network 資料夾底下 org-json/[peer org 名稱].json 檔案
-   */
-  // create new org configtx yaml
-  public async createNewOrgConfigTx (orgName: string) {
-    logger.info(`[*] Generate ${orgName} config json file: configtxgen ${this.config.infraConfig.bdkPath}/${this.config.networkName}/${orgName}/${orgName}.json`)
-
-    const orgJson = (await (new FabricTools(this.config, this.infra)).createNewOrgConfigTx(orgName)).stdout.match(/{.*}/s)?.[0] || ''
-
-    this.bdkFile.createOrgConfigJson(orgName, orgJson)
-  }
-
-  /**
    * fetch channel config to artifact/${channelName}/${channelName}_config_bock.pb
    */
   public async fetchChannelConfig (channelName: string, signType: OrgTypeEnum, orderer?: string): Promise<InfraRunnerResultType> {

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -200,13 +200,14 @@ export default class Network extends AbstractService {
     const etcdRaftConsenters: { Host: string; Port: number; ClientTLSCert: string; ServerTLSCert: string }[] = []
 
     dto.ordererOrgs.forEach(ordererOrg => {
-      configtxYaml.addOrdererOrg({
+      const newOrg = configtxYaml.addOrdererOrg({
         name: ordererOrg.name,
         mspDir: `${this.config.infraConfig.dockerPath}/ordererOrganizations/${ordererOrg.domain}/msp`,
         domain: ordererOrg.domain,
         hostname: ordererOrg.hostname,
         ports: ordererOrg.ports?.map(x => x.port),
       })
+      this.bdkFile.createConfigtxOrdererOrg(newOrg)
 
       ordererOrg.hostname.forEach((hostname, i) => {
         etcdRaftConsenters.push({
@@ -219,12 +220,13 @@ export default class Network extends AbstractService {
     })
 
     dto.peerOrgs.forEach(peerOrg => {
-      configtxYaml.addPeerOrg({
+      const newOrg = configtxYaml.addPeerOrg({
         name: peerOrg.name,
         mspDir: `${this.config.infraConfig.dockerPath}/peerOrganizations/${peerOrg.domain}/msp`,
         domain: peerOrg.domain,
         anchorPeers: [{ hostname: `peer0.${peerOrg.domain}`, port: peerOrg?.ports?.[0]?.port }],
       })
+      this.bdkFile.createConfigtxPeerOrg(newOrg)
     })
 
     configtxYaml.addSystemChannelProfile({
@@ -237,7 +239,6 @@ export default class Network extends AbstractService {
     })
 
     this.bdkFile.createConfigtx(configtxYaml)
-    this.bdkFile.createConfigtxOrgs(configtxYaml.exportOrgs())
 
     return configtxYaml
   }

--- a/src/service/orderer.ts
+++ b/src/service/orderer.ts
@@ -11,6 +11,7 @@ import { OrdererAddType, ConsenterType, OrdererUpType, OrdererAddOrgToChannelTyp
 import { InfraRunnerResultType } from '../instance/infra/InfraRunner.interface'
 import { OrgOrdererCreateType } from '../model/type/org.type'
 import { AbstractService } from './Service.abstract'
+import Org from './org'
 
 export default class Orderer extends AbstractService {
   /**
@@ -62,16 +63,17 @@ export default class Orderer extends AbstractService {
 
       const ports = ordererOrg.ports?.map(port => port.port)
 
-      configtxYaml.addOrdererOrg({
+      const newOrg = configtxYaml.addOrdererOrg({
         name: ordererOrg.name,
         mspDir: `${this.config.infraConfig.dockerPath}/ordererOrganizations/${ordererOrg.domain}/msp`,
         domain: ordererOrg.domain,
         hostname: ordererOrg.hostname,
         ports,
       })
+      this.bdkFile.createConfigtxOrdererOrg(newOrg)
+      await (new Org(this.config, this.infra)).createNewOrgConfigTx(ordererOrg.name, configtxYaml)
 
       const ordererOrgConsenter: ConsenterType[] = []
-
       ordererOrg.hostname.forEach((hostname, index) => {
         const serverCertBase64 = this.bdkFile.getOrdererServerCertToBase64(hostname, ordererOrg.domain)
 
@@ -82,11 +84,7 @@ export default class Orderer extends AbstractService {
           serverTlsCert: serverCertBase64,
         })
       })
-
-      this.bdkFile.createConfigtx(configtxYaml)
       this.bdkFile.createOrdererOrgConsenter(ordererOrg.name, JSON.stringify(ordererOrgConsenter))
-
-      await (new Channel(this.config, this.infra)).createNewOrgConfigTx(ordererOrg.name)
     }
   }
 

--- a/src/service/orderer.ts
+++ b/src/service/orderer.ts
@@ -71,7 +71,7 @@ export default class Orderer extends AbstractService {
         ports,
       })
       this.bdkFile.createConfigtxOrdererOrg(newOrg)
-      await (new Org(this.config, this.infra)).createNewOrgConfigTx(ordererOrg.name, configtxYaml)
+      await (new Org(this.config, this.infra)).createOrgDefinitionJson(ordererOrg.name, configtxYaml)
 
       const ordererOrgConsenter: ConsenterType[] = []
       ordererOrg.hostname.forEach((hostname, index) => {
@@ -84,7 +84,7 @@ export default class Orderer extends AbstractService {
           serverTlsCert: serverCertBase64,
         })
       })
-      this.bdkFile.createOrdererOrgConsenter(ordererOrg.name, JSON.stringify(ordererOrgConsenter))
+      this.bdkFile.createOrdererOrgConsenterJson(ordererOrg.name, JSON.stringify(ordererOrgConsenter))
     }
   }
 

--- a/src/service/org.ts
+++ b/src/service/org.ts
@@ -1,6 +1,8 @@
 import { logger } from '../util'
 import { OrgJsonType } from '../model/type/org.type'
 import { AbstractService } from './Service.abstract'
+import FabricTools from '../instance/fabricTools'
+import ConfigtxYaml from '../model/yaml/network/configtx'
 
 export default class Org extends AbstractService {
   /**
@@ -26,5 +28,20 @@ export default class Org extends AbstractService {
     }
 
     this.bdkFile.createExportOrgConfigJson(exportPeerOrgJson, path)
+  }
+
+  /**
+   * @description 由 config.yaml 建立 peer org 的 json 檔案
+   * @param orgName - peer org 的名稱
+   * @returns 在 blockchain network 資料夾底下 org-json/[peer org 名稱].json 檔案
+   */
+  // create new org configtx yaml
+  public async createNewOrgConfigTx (orgName: string, configtxYaml: ConfigtxYaml) {
+    logger.info(`[*] Generate ${orgName} config json file: configtxgen ${this.config.infraConfig.bdkPath}/${this.config.networkName}/org-json/${orgName}.json`)
+
+    this.bdkFile.createConfigtx(configtxYaml)
+    const orgJson = (await (new FabricTools(this.config, this.infra)).createNewOrgConfigTx(orgName)).stdout.match(/{.*}/s)?.[0] || ''
+
+    this.bdkFile.createOrgConfigJson(orgName, orgJson)
   }
 }

--- a/src/service/org.ts
+++ b/src/service/org.ts
@@ -12,7 +12,7 @@ export default class Org extends AbstractService {
     data.forEach(org => {
       logger.info(`[*] Import org config: ${org.name}`)
 
-      this.bdkFile.createOrgConfigJson(org.name, org.json)
+      this.bdkFile.createOrgDefinitionJson(org.name, org.json)
     })
   }
 
@@ -27,7 +27,7 @@ export default class Org extends AbstractService {
       json: orgJson,
     }
 
-    this.bdkFile.createExportOrgConfigJson(exportPeerOrgJson, path)
+    this.bdkFile.createExportOrgDefinitionJson(exportPeerOrgJson, path)
   }
 
   /**
@@ -36,12 +36,12 @@ export default class Org extends AbstractService {
    * @returns 在 blockchain network 資料夾底下 org-json/[peer org 名稱].json 檔案
    */
   // create new org configtx yaml
-  public async createNewOrgConfigTx (orgName: string, configtxYaml: ConfigtxYaml) {
+  public async createOrgDefinitionJson (orgName: string, configtxYaml: ConfigtxYaml) {
     logger.info(`[*] Generate ${orgName} config json file: configtxgen ${this.config.infraConfig.bdkPath}/${this.config.networkName}/org-json/${orgName}.json`)
 
     this.bdkFile.createConfigtx(configtxYaml)
-    const orgJson = (await (new FabricTools(this.config, this.infra)).createNewOrgConfigTx(orgName)).stdout.match(/{.*}/s)?.[0] || ''
+    const orgJson = (await (new FabricTools(this.config, this.infra)).printOrgDefinitionJson(orgName)).stdout.match(/{.*}/s)?.[0] || ''
 
-    this.bdkFile.createOrgConfigJson(orgName, orgJson)
+    this.bdkFile.createOrgDefinitionJson(orgName, orgJson)
   }
 }

--- a/src/service/peer.ts
+++ b/src/service/peer.ts
@@ -14,6 +14,7 @@ import { PeerUpType, PeerDownType, PeerAddType, PeerAddOrgToChannelType, PeerApp
 import { InfraRunnerResultType } from '../instance/infra/InfraRunner.interface'
 import { OrgPeerCreateType } from '../model/type/org.type'
 import { AbstractService } from './Service.abstract'
+import Org from './org'
 
 export default class Peer extends AbstractService {
   /**
@@ -63,16 +64,14 @@ export default class Peer extends AbstractService {
     for (const peerOrg of peerOrgs) {
       logger.info(`[*] Peer create configtx: ${peerOrg.name}`)
 
-      configtxYaml.addPeerOrg({
+      const newOrg = configtxYaml.addPeerOrg({
         name: peerOrg.name,
         mspDir: `${this.config.infraConfig.dockerPath}/peerOrganizations/${peerOrg.domain}/msp`,
         domain: peerOrg.domain,
         anchorPeers: [{ hostname: `${this.config.hostname}.${this.config.orgDomainName}`, port: peerOrg?.ports?.[+(this.config.hostname.slice(4, 0))]?.port }],
       })
-
-      this.bdkFile.createConfigtx(configtxYaml)
-
-      await (new Channel(this.config, this.infra)).createNewOrgConfigTx(peerOrg.name)
+      this.bdkFile.createConfigtxPeerOrg(newOrg)
+      await (new Org(this.config, this.infra)).createNewOrgConfigTx(peerOrg.name, configtxYaml)
     }
   }
 

--- a/src/service/peer.ts
+++ b/src/service/peer.ts
@@ -71,7 +71,7 @@ export default class Peer extends AbstractService {
         anchorPeers: [{ hostname: `${this.config.hostname}.${this.config.orgDomainName}`, port: peerOrg?.ports?.[+(this.config.hostname.slice(4, 0))]?.port }],
       })
       this.bdkFile.createConfigtxPeerOrg(newOrg)
-      await (new Org(this.config, this.infra)).createNewOrgConfigTx(peerOrg.name, configtxYaml)
+      await (new Org(this.config, this.infra)).createOrgDefinitionJson(peerOrg.name, configtxYaml)
     }
   }
 

--- a/test/service/network.test.ts
+++ b/test/service/network.test.ts
@@ -35,7 +35,11 @@
 //     await network.create(networkCreateDto)
 //     let files_should_exist = [
 //       'config-yaml/configtx.yaml',
-//       'config-yaml/configtxOrgs.json',
+//       'config-yaml/orgs/peer-Ben.json',
+//       'config-yaml/orgs/peer-Grace.json',
+//       'config-yaml/orgs/peer-Eugene.json',
+//       'config-yaml/orgs/orderer-BenOrderer.json',
+//       'config-yaml/orgs/orderer-GraceOrderer.json',
 //       'config-yaml/crypto-config.yaml',
 //       'docker-compose/docker-compose-orderer-orderer0.ben.cathaybc.com.yaml',
 //       'docker-compose/docker-compose-orderer-orderer1.ben.cathaybc.com.yaml',


### PR DESCRIPTION
# PULL REQUEST

## 說明 (Description)

`network create` 時會產生 `config-yaml/configtxOrgs.json` ，在channel create時會成為org的選項
但是 `peer create` 時，新的peer org 不會被加到這個檔案，導致新組織無法再 `channel create` 時被選擇

此PR的改成在1個org就是一個檔案，在 `network create` 與 `peer/orderer create` 時都會產生此檔案。
檔案名稱：
舊：`config-yaml/configtxOrgs.json`
新：`config-yaml/orgs/[peer/orderer]-[orgName].json`

## 相關問題 (Linked Issues)
- 新組織無法在 `channel create` 時選擇

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [x] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
*OS: Ubuntu 20.04.3 LTS (GNU/Linux 5.11.0-1020-gcp x86_64)
*NodeJS Version: v16.13.1
*NPM Version: 8.2.0
*Docker Version: 20.10.9


## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [x] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [x] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [x] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [ ] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [x] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
