### PR TITLE
Fix explorer

### DIFF
--- a/cicd/test_script/ca-gen.sh
+++ b/cicd/test_script/ca-gen.sh
@@ -126,7 +126,7 @@ bdk ca enroll -t user -u ${ICA_DOMAIN_EUGENE} -p 10054 --client-id Admin@${PEER_
 # ================================================================================================
 
 # Network create
-bdk network create -f ./cicd/test_script/network-create.json --genesis --connection-config --docker-compose
+bdk network create -f ./cicd/test_script/network-create.json --genesis --connection-profile --docker-compose
 
 bdk orderer up -n orderer0.${ORDERER_ORG_DOMAIN_BEN} -n orderer0.${ORDERER_ORG_DOMAIN_GRACE} -n orderer1.${ORDERER_ORG_DOMAIN_BEN}
 sleep 2
@@ -273,7 +273,7 @@ bdk ca enroll -t user -u ${ICA_DOMAIN_ERIC} -p 11054 --client-id Admin@${PEER_OR
 
 # ==================================================================
 # [Eric] create new org
-bdk org peer create -f ./cicd/test_script/org-peer-create.json --configtxJSON --connection-config --docker-compose
+bdk org peer create -f ./cicd/test_script/org-peer-create.json --configtxJSON --connection-profile --docker-compose
 
 # [Eric] export & import org json config
 export_env 'peer' 'Eric' ${PEER_ORG_DOMAIN_ERIC} 'peer0'

--- a/cicd/test_script/ca-gen.sh
+++ b/cicd/test_script/ca-gen.sh
@@ -168,6 +168,12 @@ bdk channel join -n ryan --orderer orderer1.${ORDERER_ORG_DOMAIN_BEN}:7150
 bdk channel update-anchorpeer -n ryan --orderer orderer0.${ORDERER_ORG_DOMAIN_GRACE}:7250 -p 7251
 
 # ==========================================================================================
+# explorer
+export_env 'peer' 'Ben' ${PEER_ORG_DOMAIN_BEN} 'peer0'
+bdk explorer up
+sleep 5
+curl http://localhost:8080
+# ==========================================================================================
 # package
 bdk chaincode package -n fabcar -v 1 -p ./chaincode/fabcar/go
 

--- a/cicd/test_script/crypto-gen.sh
+++ b/cicd/test_script/crypto-gen.sh
@@ -69,7 +69,12 @@ bdk channel join -n ${CHANNEL_NAME} --orderer orderer0.${ORDERER_ORG_DOMAIN_GRAC
 export_env 'peer' 'Eugene' ${PEER_ORG_DOMAIN_EUGENE} 'peer0'
 bdk channel join -n ${CHANNEL_NAME} --orderer orderer1.${ORDERER_ORG_DOMAIN_BEN}:7150
 bdk channel update-anchorpeer -n ${CHANNEL_NAME} --orderer orderer0.${ORDERER_ORG_DOMAIN_GRACE}:7250 -p 7251
-
+# ==========================================================================================
+# explorer
+export_env 'peer' 'Ben' ${PEER_ORG_DOMAIN_BEN} 'peer0'
+bdk explorer up
+sleep 2
+curl http://localhost:8080
 # ==========================================================================================
 # package
 bdk chaincode package -n ${CHAINCODE_NAME} -v 1 -p ./chaincode/fabcar/go

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -344,7 +344,7 @@ Description: 產生 Blockchain network 所需的相關設定檔案
 | --create-full       | boolean | 是否產生 Blockchain network 所需要的所有相關設定檔案（包含使用 cryptogen 產生憑證和私鑰、產生創始區塊、產生 Peer 連接設定檔案、產生 Peer/Orderer docker-compose 檔案） |          | false   |
 | --cryptogen         | boolean | 是否使用 cryptogen 產生憑證和私鑰                                                                                                                                      |          | false   |
 | --genesis           | boolean | 是否產生創始區塊                                                                                                                                                       |          | false   |
-| --connection-config | boolean | 是否產生 Peer 連接設定檔案                                                                                                                                             |          | false   |
+| --connection-profile | boolean | 是否產生 Peer 連接設定檔案                                                                                                                                             |          | false   |
 | --docker-compose    | boolean | 是否產生 Peer/Orderer docker-compose 檔案                                                                                                                              |          | false   |
 | --test-network      | boolean | 建立測試用的 Blockchain Network                                                                                                                                        |          | false   |
 
@@ -482,7 +482,7 @@ Description: 產生欲加入 Blockchin network 的 Orderer org 所需的相關�
 | --create-full           | boolean | 是否產生 Hyperledger Fabric 所需要的所有相關設定檔案（包含使用 cryptogen 產生憑證和私鑰、使用 configtx.yaml 產生 Orderer org 的 json 檔案、產生 Orderer docker-compose 檔案） |          | false   |
 | --cryptogen             | boolean | 是否使用 cryptogen 產生憑證和私鑰                                                                                                                                             |          | false   |
 | --configtxJSON          | boolean | 是否使用 configtx.yaml 產生 Orderer Org 的 json 檔案                                                                                                                          |          | false   |
-| --connection-config     | boolean | 是否產生 Orderer 連接設定檔案                                                                                                                                                 |          | false   |
+| --connection-profile     | boolean | 是否產生 Orderer 連接設定檔案                                                                                                                                                 |          | false   |
 | --docker-compose        | boolean | 是否產生 Orderer docker-compose 檔案                                                                                                                                          |          | false   |
 
 ### `bdk org orderer update`
@@ -532,7 +532,7 @@ Description: 產生欲加入 Channel 的 Peer org 所需的相關設定檔案
 | --create-full       | boolean | 是否產生 Hyperledger Fabric 所需要的所有相關設定檔案（包含使用 cryptogen 產生憑證和私鑰、使用 configtx.yaml 產生 Peer org 的 json 檔案、產生 Peer 連接設定檔案、產生 Peer/Orderer docker-compose 檔案） |          | false   |
 | --cryptogen         | boolean | 是否使用 cryptogen 產生憑證和私鑰                                                                                                                                                                       |          | false   |
 | --configtxJSON      | boolean | 是否使用 configtx.yaml 產生 Peer Org 的 json 檔案                                                                                                                                                       |          | false   |
-| --connection-config | boolean | 是否產生 Peer 連接設定檔案                                                                                                                                                                              |          | false   |
+| --connection-profile | boolean | 是否產生 Peer 連接設定檔案                                                                                                                                                                              |          | false   |
 | --docker-compose    | boolean | 是否產生 Peer docker-compose 檔案                                                                                                                                                                       |          | false   |
 
 ### `bdk org peer update`

--- a/src/command/explorer/up.ts
+++ b/src/command/explorer/up.ts
@@ -1,19 +1,59 @@
 import { Arguments, Argv } from 'yargs'
 import Explorer from '../../service/explorer'
-import { logger } from '../../util'
+import { logger, onCancel } from '../../util'
 import config from '../../config'
+import prompts from 'prompts'
 
 export const command = 'up'
 
 export const desc = '啟動 Blockchain explorer'
 
-export const builder = (yargs: Argv) => {
-  return yargs
+interface OptType {
+  interactive: boolean
+  user: string
+  pass: string
+  port: number
 }
 
-export const handler = async (argv: Arguments) => {
-  logger.debug('exec explorer up')
+export const builder = (yargs: Argv<OptType>) => {
+  return yargs
+    .option('interactive', { type: 'boolean', description: '是否使用 Cathay BDK 互動式問答', alias: 'i', default: false })
+    .option('user', { type: 'string', description: 'explorer 的預設使用者名稱', alias: 'u', default: 'exploreradmin' })
+    .option('pass', { type: 'string', description: 'explorer 的預設使用者密碼', alias: 'p', default: 'exploreradminpw' })
+    .option('port', { type: 'number', description: 'explorer 的預設使用者名稱', alias: 'P', default: 8080 })
+    .example('bdk explorer up --interactive', 'Cathay BDK 互動式問答')
+    .example('bdk explorer up --user alice --pass pass123 --port 8080', '建立 explore ，使用者帳號為 alice ，密碼為 pass123 ，使用的 port 是 8080')
+}
 
+export const handler = async (argv: Arguments<OptType>) => {
+  logger.debug('exec explorer up')
   const explorer = new Explorer(config)
-  await explorer.upForMyOrg()
+  let explorerUpInput
+
+  if (argv.interactive) {
+    explorerUpInput = await prompts([
+      {
+        type: 'text',
+        name: 'user',
+        message: 'What is your explorer default username?',
+        initial: 'exploreradmin',
+      },
+      {
+        type: 'text',
+        name: 'pass',
+        message: 'What is your explorer default password?',
+        initial: 'exploreradminpw',
+      },
+      {
+        type: 'number',
+        name: 'port',
+        message: 'What is your channel name?',
+        initial: '8080',
+      },
+    ], { onCancel })
+  } else {
+    explorerUpInput = argv
+  }
+
+  await explorer.upForMyOrg(explorerUpInput)
 }

--- a/src/command/explorer/up.ts
+++ b/src/command/explorer/up.ts
@@ -1,56 +1,19 @@
 import { Arguments, Argv } from 'yargs'
 import Explorer from '../../service/explorer'
-import prompts from 'prompts'
-import { logger, ParamsError } from '../../util'
-import Peer from '../../service/peer'
-import { ExplorerUpForMyOrgType } from '../../model/type/explorer.type'
+import { logger } from '../../util'
 import config from '../../config'
 
 export const command = 'up'
 
 export const desc = '啟動 Blockchain explorer'
 
-interface OptType {
-  interactive: boolean
-  peerAddress: string
-}
-
-export const builder = (yargs: Argv<OptType>) => {
+export const builder = (yargs: Argv) => {
   return yargs
-    .example('bdk explorer up --interactive', 'Cathay BDK 互動式問答')
-    .example('bdk explorer up --peer-address peer0.example.com:7050', '啟動 Blockchain explorer 並且從 peer0.example.com:7051 取得資訊')
-    .option('interactive', { type: 'boolean', description: '是否使用 Cathay BDK 互動式問答', alias: 'i' })
-    .option('peer-address', { type: 'string', description: '連接 Peer 的 address 和 port', alias: 'p' })
 }
 
-export const handler = async (argv: Arguments<OptType>) => {
+export const handler = async (argv: Arguments) => {
   logger.debug('exec explorer up')
 
   const explorer = new Explorer(config)
-  const peer = new Peer(config)
-
-  const peerAddress: string = await (async () => {
-    if (argv.interactive) {
-      return (await prompts([
-        {
-          type: 'select',
-          name: 'peerAddress',
-          message: 'Peer address',
-          choices: peer.getPeerAddressList().map(x => ({
-            title: x,
-            value: x,
-          })),
-        }])).peerAddress
-    } else if (argv.peerAddress) {
-      return argv.peerAddress
-    } else {
-      throw new ParamsError('Invalid params: Required parameter <peer-address> missing')
-    }
-  })()
-
-  const upForMyOrg: ExplorerUpForMyOrgType = {
-    peerAddress,
-  }
-
-  await explorer.upForMyOrg(upForMyOrg)
+  await explorer.upForMyOrg()
 }

--- a/src/command/explorer/update.ts
+++ b/src/command/explorer/update.ts
@@ -10,46 +10,14 @@ export const command = 'update'
 
 export const desc = '更新 Blockchain explorer 連接的 Peer'
 
-interface OptType {
-  interactive: boolean
-  peerAddress: string
-}
-
-export const builder = (yargs: Argv<OptType>) => {
+export const builder = (yargs: Argv) => {
   return yargs
-    .example('bdk explorer update --interactive', 'Cathay BDK 互動式問答')
-    .example('bdk explorer update --peer-address peer1.example.com:8051', '更新 Blockchain explorer 從 peer1.example.com:8051 取得資訊')
-    .option('interactive', { type: 'boolean', description: '是否使用 Cathay BDK 互動式問答', alias: 'i' })
-    .option('peer-address', { type: 'string', description: 'peer address and port', alias: 'p' })
 }
 
-export const handler = async (argv: Arguments<OptType>) => {
+export const handler = async (argv: Arguments) => {
   logger.debug('exec explorer update')
 
   const explorer = new Explorer(config)
-  const peer = new Peer(config)
 
-  const peerAddress: string = await (async () => {
-    if (argv.interactive) {
-      return (await prompts([
-        {
-          type: 'select',
-          name: 'peerAddress',
-          message: 'Peer address',
-          choices: peer.getPeerAddressList().map(x => ({
-            title: x,
-            value: x,
-          })),
-        }])).peerAddress
-    } else if (argv.peerAddress) {
-      return argv.peerAddress
-    } else {
-      throw new ParamsError('Invalid params: Required parameter <peer-address> missing')
-    }
-  })()
-
-  const upForMyOrg: ExplorerUpForMyOrgType = {
-    peerAddress,
-  }
-  await explorer.updateForMyOrg(upForMyOrg)
+  await explorer.updateForMyOrg()
 }

--- a/src/command/explorer/update.ts
+++ b/src/command/explorer/update.ts
@@ -1,9 +1,6 @@
 import { Arguments, Argv } from 'yargs'
 import Explorer from '../../service/explorer'
-import prompts from 'prompts'
-import { logger, ParamsError } from '../../util'
-import Peer from '../../service/peer'
-import { ExplorerUpForMyOrgType } from '../../model/type/explorer.type'
+import { logger } from '../../util'
 import config from '../../config'
 
 export const command = 'update'

--- a/src/command/network/create.ts
+++ b/src/command/network/create.ts
@@ -21,7 +21,7 @@ interface OptType {
   createFull: boolean
   cryptogen: boolean
   genesis: boolean
-  connectionConfig: boolean
+  connectionProfile: boolean
   dockerCompose: boolean
   testNetwork: boolean
 }
@@ -32,14 +32,14 @@ export const builder = (yargs: Argv<OptType>) => {
     .example('bdk network create --file ~/.bdk/network-create.json --create-full', '使用在路徑下 json 檔案中的參數，產生 Blockchain network 所需的相關設定檔案')
     .example('bdk network create --file ~/.bdk/network-create.json --cryptogen', '使用在路徑下 json 檔案中的參數和 cryptogen，產生憑證和私鑰')
     .example('bdk network create --file ~/.bdk/network-create.json --genesis', '使用在路徑下 json 檔案中的參數，產生創始區塊')
-    .example('bdk network create --file ~/.bdk/network-create.json --connection-config', '使用在路徑下 json 檔案中的參數，產生 Peer 連接設定檔案')
+    .example('bdk network create --file ~/.bdk/network-create.json --connection-profile', '使用在路徑下 json 檔案中的參數，產生 Peer 連接設定檔案')
     .example('bdk network create --file ~/.bdk/network-create.json --docker-compose', '使用在路徑下 json 檔案中的參數，產生 Peer/Orderer docker-compose 檔案')
     .option('file', { type: 'string', description: '需要的參數設定 json 檔案路徑', alias: 'f' })
     .option('interactive', { type: 'boolean', description: '是否使用 Cathay BDK 互動式問答', alias: 'i', default: false })
     .option('create-full', { type: 'boolean', description: '是否產生 Blockchain network 所需要的所有相關設定檔案（包含使用 cryptogen 產生憑證和私鑰、產生創始區塊、產生 Peer 連接設定檔案、產生 Peer/Orderer docker-compose 檔案）', default: false })
     .option('cryptogen', { type: 'boolean', description: '是否使用 cryptogen 產生憑證和私鑰', default: false })
     .option('genesis', { type: 'boolean', description: '是否產生創始區塊', default: false })
-    .option('connection-config', { type: 'boolean', description: '是否產生 Peer 連接設定檔案', default: false })
+    .option('connection-profile', { type: 'boolean', description: '是否產生 Peer 連接設定檔案', default: false })
     .option('docker-compose', { type: 'boolean', description: '是否產生 Peer/Orderer docker-compose 檔案', default: false })
     .option('test-network', { type: 'boolean', description: '建立測試用的 Blockchain Network', default: false })
 }
@@ -148,17 +148,17 @@ export const handler = async (argv: Arguments<OptType>) => {
     }
   })()
 
-  const connectionConfig: boolean = await (async () => {
+  const connectionProfile: boolean = await (async () => {
     if (argv.interactive) {
       return (await prompts(
         {
           type: 'confirm',
-          name: 'connectionConfig',
-          message: 'Do you want to generate peer connection config profile?',
+          name: 'connectionProfile',
+          message: 'Do you want to generate peer connection profile?',
           initial: false,
-        }, { onCancel })).connectionConfig
+        }, { onCancel })).connectionProfile
     } else {
-      return argv.connectionConfig
+      return argv.connectionProfile
     }
   })()
 
@@ -188,8 +188,8 @@ export const handler = async (argv: Arguments<OptType>) => {
     await network.createGenesisBlock(networkCreate)
   }
 
-  if (connectionConfig || createFull) {
-    network.createConnectionConfig(networkCreate)
+  if (connectionProfile || createFull) {
+    network.createConnectionProfile(networkCreate)
   }
 
   if (dockerCompose || createFull) {

--- a/src/command/org/peer/create.ts
+++ b/src/command/org/peer/create.ts
@@ -18,7 +18,7 @@ interface OptType {
   createFull: boolean
   cryptogen: boolean
   configtxJSON: boolean
-  connectionConfig: boolean
+  connectionProfile: boolean
   dockerCompose: boolean
 }
 
@@ -28,14 +28,14 @@ export const builder = (yargs: Argv<OptType>) => {
     .example('bdk org peer create --file ~/.bdk/org-peer-create.json --create-full', '使用在路徑下 json 檔案中的參數，產生 Peer org 所需的相關設定檔案')
     .example('bdk org peer create --file ~/.bdk/org-peer-create.json --cryptogen', '使用在路徑下 json 檔案中的參數和 cryptogen，產生憑證和私鑰')
     .example('bdk org peer create --file ~/.bdk/org-peer-create.json --configtxJSON', '使用在路徑下 json 檔案中的參數和 configtx.yaml 產生 Peer org 的 json 檔案')
-    .example('bdk org peer create --file ~/.bdk/org-peer-create.json --connection-config', '使用在路徑下 json 檔案中的參數，產生 Peer 連接設定檔案')
+    .example('bdk org peer create --file ~/.bdk/org-peer-create.json --connection-profile', '使用在路徑下 json 檔案中的參數，產生 Peer 連接設定檔案')
     .example('bdk org peer create --file ~/.bdk/org-peer-create.json --docker-compose', '使用在路徑下 json 檔案中的參數，產生 Peer docker-compose 檔案')
     .option('file', { type: 'string', description: '需要的參數設定 json 檔案路徑', alias: 'f' })
     .option('interactive', { type: 'boolean', description: '是否使用 Cathay BDK 互動式問答', alias: 'i' })
     .option('create-full', { type: 'boolean', description: '是否產生 Hyperledger Fabric 所需要的所有相關設定檔案（包含使用 cryptogen 產生憑證和私鑰、使用 configtx.yaml 產生 Peer org 的 json 檔案、產生 Peer 連接設定檔案、產生 Peer/Orderer docker-compose 檔案）', default: false })
     .option('cryptogen', { type: 'boolean', description: '是否使用 cryptogen 產生憑證和私鑰', default: false })
     .option('configtxJSON', { type: 'boolean', description: '是否使用 configtx.yaml 產生 Peer Org 的 json 檔案', default: false })
-    .option('connection-config', { type: 'boolean', description: '是否產生 Peer 連接設定檔案', default: false })
+    .option('connection-profile', { type: 'boolean', description: '是否產生 Peer 連接設定檔案', default: false })
     .option('docker-compose', { type: 'boolean', description: '是否產生 Peer docker-compose 檔案', default: false })
 }
 
@@ -125,17 +125,17 @@ export const handler = async (argv: Arguments<OptType>) => {
     }
   })()
 
-  const connectionConfig: boolean = await (async () => {
+  const connectionProfile: boolean = await (async () => {
     if (argv.interactive) {
       return (await prompts(
         {
           type: 'confirm',
-          name: 'connectionConfig',
-          message: 'Do you want to generate peer connection config profile?',
+          name: 'connectionProfile',
+          message: 'Do you want to generate peer connection profile?',
           initial: false,
-        }, { onCancel })).connectionConfig
+        }, { onCancel })).connectionProfile
     } else {
-      return argv.connectionConfig
+      return argv.connectionProfile
     }
   })()
 
@@ -163,8 +163,8 @@ export const handler = async (argv: Arguments<OptType>) => {
     await peer.createPeerOrgConfigtxJSON(orgPeerCreate)
   }
 
-  if (connectionConfig || argv.createFull) {
-    peer.createConnectionConfigYaml(orgPeerCreate)
+  if (connectionProfile || argv.createFull) {
+    peer.createConnectionProfileYaml(orgPeerCreate)
   }
 
   if (dockerCompose || argv.createFull) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { ChaincodePackageType, ChaincodeApproveType, ChaincodeCommitType, Chainc
 export { PolicyTypeEnum, PolicyStyleEnum, ChannelPolicyType, ChannelCreateType, ChannelJoinType, ChannelUpdateAnchorPeerType, ConfigtxlatorEnum, ChannelCreateChannelConfigComputeType, ChannelCreateChannelConfigSignType, ChannelCreateChannelConfigUpdateType, ChannelConfigEnum, ChannelFetchBlockType } from './model/type/channel.type'
 export { ConfigEnvType, ConfigSetType } from './model/type/config.type'
 export { DockerHostConfigType, DockerCreateOptionsType, DockerStartOptionsType, DockerRunCommandType } from './model/type/docker.type'
-export { ExplorerUpForMyOrgType } from './model/type/explorer.type'
+export { ExplorerUpForMyOrgType, ExplorerUpdateForMyOrgType, ExplorerChannelType } from './model/type/explorer.type'
 export { NetworkCreateType, NetworkCryptoConfigOrdererOrgType, NetworkCryptoConfigPeerOrgType, NetworkCreateOrdererOrgType, NetworkCreatePeerOrgType, NetworkOrdererPortType, NetworkPeerPortType } from './model/type/network.type'
 export { OrgPeerOrgNameAndDomainType, OrgJsonType, OrgOrdererCreateType, OrgPeerCreateType } from './model/type/org.type'
 export { PeerUpType, PeerDownType, PeerAddType, PeerAddOrgToChannelType, PeerApproveType, PeerUpdateType } from './model/type/peer.type'

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { ChaincodePackageType, ChaincodeApproveType, ChaincodeCommitType, Chainc
 export { PolicyTypeEnum, PolicyStyleEnum, ChannelPolicyType, ChannelCreateType, ChannelJoinType, ChannelUpdateAnchorPeerType, ConfigtxlatorEnum, ChannelCreateChannelConfigComputeType, ChannelCreateChannelConfigSignType, ChannelCreateChannelConfigUpdateType, ChannelConfigEnum, ChannelFetchBlockType } from './model/type/channel.type'
 export { ConfigEnvType, ConfigSetType } from './model/type/config.type'
 export { DockerHostConfigType, DockerCreateOptionsType, DockerStartOptionsType, DockerRunCommandType } from './model/type/docker.type'
-export { ExplorerConfigType, ExplorerUpForMyOrgType } from './model/type/explorer.type'
+export { ExplorerUpForMyOrgType } from './model/type/explorer.type'
 export { NetworkCreateType, NetworkCryptoConfigOrdererOrgType, NetworkCryptoConfigPeerOrgType, NetworkCreateOrdererOrgType, NetworkCreatePeerOrgType, NetworkOrdererPortType, NetworkPeerPortType } from './model/type/network.type'
 export { OrgPeerOrgNameAndDomainType, OrgJsonType, OrgOrdererCreateType, OrgPeerCreateType } from './model/type/org.type'
 export { PeerUpType, PeerDownType, PeerAddType, PeerAddOrgToChannelType, PeerApproveType, PeerUpdateType } from './model/type/peer.type'

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -13,6 +13,8 @@ import { OrgJsonType } from '../model/type/org.type'
 import { ProcessError } from '../util'
 import { Config } from '../config'
 import { DockerComposeYamlInterface } from '../model/yaml/docker-compose/dockerComposeYaml'
+import ExplorerConnectionProfileYaml from '../model/yaml/explorer/explorerConnectionProfileYaml'
+import ExplorerConfigYaml from '../model/yaml/explorer/explorerConfigYaml'
 import ExplorerDockerComposeYaml from '../model/yaml/docker-compose/explorerDockerComposeYaml'
 
 export enum InstanceTypeEnum {
@@ -158,11 +160,15 @@ export default class BdkFile {
     fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.yaml`, connectionConfigYaml.getYamlString())
   }
 
+  public getConnectionFile (name: string, domain: string): ConnectionProfileYaml {
+    return new ConnectionProfileYaml(JSON.parse(fs.readFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.json`).toString()))
+  }
+
   public getDockerComposeYamlPath (hostName: string, type: InstanceTypeEnum): string {
     return `${this.bdkPath}/docker-compose/docker-compose-${type}-${hostName}.yaml`
   }
 
-  public getExplorerRootFilePath () {
+  private getExplorerRootFilePath () {
     return `${this.bdkPath}/fabric-explorer`
   }
 
@@ -241,6 +247,24 @@ export default class BdkFile {
 
   public createChannelConfigJson (channelName: string, fileName: string, channelConfigJson: string) {
     fs.writeFileSync(`${this.bdkPath}/channel-artifacts/${channelName}/${fileName}.json`, channelConfigJson)
+  }
+
+  public createExplorerConnectionProfile (networkName: string, explorerConnectionProfileYaml: ExplorerConnectionProfileYaml) {
+    this.createExplorerFolder()
+    fs.writeFileSync(
+      `${this.getExplorerRootFilePath()}/connection-profile/${networkName}.json`, explorerConnectionProfileYaml.getJsonString(),
+    )
+  }
+
+  public createExplorerConfig (explorerConfig: ExplorerConfigYaml) {
+    this.createExplorerFolder()
+    fs.writeFileSync(
+      `${this.getExplorerRootFilePath()}/config.json`, explorerConfig.getJsonString(),
+    )
+  }
+
+  public getExplorerConfig (): ExplorerConfigYaml {
+    return new ExplorerConfigYaml(JSON.parse(fs.readFileSync(`${this.getExplorerRootFilePath()}/config.json`).toString()))
   }
 
   public getDockerComposeList (): {peer: string[]; orderer: string[]; ca: string[]} {

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -155,9 +155,9 @@ export default class BdkFile {
     return fs.readFileSync(`${this.bdkPath}/org-json/${name}-consenter.json`).toString()
   }
 
-  public createConnectionFile (name: string, domain: string, connectionConfigYaml: ConnectionProfileYaml) {
-    fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.json`, connectionConfigYaml.getJsonString())
-    fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.yaml`, connectionConfigYaml.getYamlString())
+  public createConnectionFile (name: string, domain: string, connectionProfileYaml: ConnectionProfileYaml) {
+    fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.json`, connectionProfileYaml.getJsonString())
+    fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.yaml`, connectionProfileYaml.getYamlString())
   }
 
   public getConnectionFile (name: string, domain: string): ConnectionProfileYaml {

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -13,6 +13,7 @@ import { OrgJsonType } from '../model/type/org.type'
 import { ProcessError } from '../util'
 import { Config } from '../config'
 import { DockerComposeYamlInterface } from '../model/yaml/docker-compose/dockerComposeYaml'
+import ExplorerDockerComposeYaml from '../model/yaml/docker-compose/explorerDockerComposeYaml'
 
 export enum InstanceTypeEnum {
   ca = 'ca',
@@ -165,6 +166,10 @@ export default class BdkFile {
     return `${this.bdkPath}/fabric-explorer`
   }
 
+  private createExplorerFolder () {
+    fs.mkdirSync(`${this.getExplorerRootFilePath()}/connection-profile`, { recursive: true })
+  }
+
   public getExplorerDockerComposeYamlPath (): string {
     return `${this.getExplorerRootFilePath()}/docker-compose.yaml`
   }
@@ -183,6 +188,11 @@ export default class BdkFile {
 
     fs.mkdirSync(`${this.bdkPath}/docker-compose`, { recursive: true })
     fs.writeFileSync(this.getDockerComposeYamlPath(hostName, type), dockerComposeYaml.getYamlString())
+  }
+
+  public createExplorerDockerComposeYaml (explorerConnectionProfileYaml: ExplorerDockerComposeYaml) {
+    this.createExplorerFolder()
+    fs.writeFileSync(this.getExplorerDockerComposeYamlPath(), explorerConnectionProfileYaml.getYamlString())
   }
 
   public getDockerComposeYaml (hostName: string, type: InstanceTypeEnum): DockerComposeYamlInterface {

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra'
 import YAML from 'js-yaml'
 import { parse, stringify } from 'envfile'
 import CryptoConfigYaml from '../model/yaml/network/cryptoConfigYaml'
-import ConnectionConfigYaml from '../model/yaml/network/connectionConfigYaml'
+import ConnectionProfileYaml from '../model/yaml/network/connectionProfileYaml'
 import ConfigtxYaml, { ConfigtxOrgs, OrdererOrganizationInterface, PeerOrganizationInterface } from '../model/yaml/network/configtx'
 import { ConfigEnvType } from '../model/type/config.type'
 import OrdererDockerComposeYaml from '../model/yaml/docker-compose/ordererDockerComposeYaml'
@@ -152,7 +152,7 @@ export default class BdkFile {
     return fs.readFileSync(`${this.bdkPath}/org-json/${name}-consenter.json`).toString()
   }
 
-  public createConnectionFile (name: string, domain: string, connectionConfigYaml: ConnectionConfigYaml) {
+  public createConnectionFile (name: string, domain: string, connectionConfigYaml: ConnectionProfileYaml) {
     fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.json`, connectionConfigYaml.getJsonString())
     fs.writeFileSync(`${this.bdkPath}/peerOrganizations/${domain}/connection-${name}.yaml`, connectionConfigYaml.getYamlString())
   }

--- a/src/instance/bdkFile.ts
+++ b/src/instance/bdkFile.ts
@@ -444,4 +444,12 @@ export default class BdkFile {
   public getDecodedChannelConfig (channelName: string): any {
     return JSON.parse(fs.readFileSync(`${this.bdkPath}/channel-artifacts/${channelName}/${channelName}.json`).toString())
   }
+
+  public getAdminPrivateKeyPem (domain: string): string {
+    return fs.readFileSync(this.newestFileInFolder(`${this.bdkPath}/peerOrganizations/${domain}/users/Admin@${domain}/msp/keystore`)).toString()
+  }
+
+  public getAdminSignCert (domain: string): string {
+    return fs.readFileSync(this.newestFileInFolder(`${this.bdkPath}/peerOrganizations/${domain}/users/Admin@${domain}/msp/signcerts`)).toString()
+  }
 }

--- a/src/instance/explorer.ts
+++ b/src/instance/explorer.ts
@@ -23,6 +23,6 @@ export default class Explorer extends AbstractInstance {
 
   public async restart (): Promise<InfraRunnerResultType> {
     logger.info('[*] Explorer instance restart')
-    return await this.infra.restart(this.dockerComposePath, ['explorer.bdk-network'])
+    return await this.infra.restart(this.dockerComposePath, [`explorer.${this.config.networkName}`])
   }
 }

--- a/src/model/type/explorer.type.ts
+++ b/src/model/type/explorer.type.ts
@@ -5,10 +5,11 @@ export interface ExplorerChannelType {
 /**
  * @requires channels - channel 與 加入此 Channel 的 hostname
  */
-export interface ExplorerUpForMyOrgType extends ExplorerUpdateForMyOrgType{
+export interface ExplorerUpForMyOrgType{
   user: string
   pass: string
   port: number
+  channels?: ExplorerChannelType // {'my_channel': {hostname: 'peer0'}}
 }
 
 /**

--- a/src/model/type/explorer.type.ts
+++ b/src/model/type/explorer.type.ts
@@ -1,6 +1,19 @@
+export interface ExplorerChannelType {
+  [channelName: string]: {hostname: string}
+}
+
 /**
  * @requires channels - channel 與 加入此 Channel 的 hostname
  */
-export interface ExplorerUpForMyOrgType{
-  channels?: {[channelName: string]: {hostname: string}} // {'my_channel': {hostname: 'peer0'}}
+export interface ExplorerUpForMyOrgType extends ExplorerUpdateForMyOrgType{
+  user: string
+  pass: string
+  port: number
+}
+
+/**
+ * @requires channels - channel 與 加入此 Channel 的 hostname
+ */
+export interface ExplorerUpdateForMyOrgType {
+  channels?: ExplorerChannelType // {'my_channel': {hostname: 'peer0'}}
 }

--- a/src/model/type/explorer.type.ts
+++ b/src/model/type/explorer.type.ts
@@ -1,33 +1,6 @@
 /**
- * @requires networkName - [string] blockchain network 的名稱
- * @requires orgs - [object] peer org 的資訊
- * @requires channels - [object] channel 的資訊
- * @requires clientOrganization - [string] 連接 peer org 的名稱
- */
-export interface ExplorerConfigType {
-  networkName: string
-  orgs: {
-    [orgName: string]: { // Org1
-      domain: string // org1.example.com
-      peers: {
-        url: string
-        port: number
-      }[] // [{url: 'peer0.org1.example.com', port: 7051}, {url: 'peer0.org2.example.com', port: 7051}]
-    }
-  }
-  channels: {
-    [channelName: string]: { // mychannel
-      orgs: string[] // ['Org1', 'Org2']
-    }
-  }
-  clientOrganization: string // Org1
-}
-
-/**
- * @requires peerAddress - peer 的 address
- * @requires orgDomainName - peer org 的 domain 名稱
+ * @requires channels - channel 與 加入此 Channel 的 hostname
  */
 export interface ExplorerUpForMyOrgType{
-  peerAddress: string
-  joinedChannel?: string[]
+  channels?: {[channelName: string]: {hostname: string}} // {'my_channel': {hostname: 'peer0'}}
 }

--- a/src/model/type/explorer.type.ts
+++ b/src/model/type/explorer.type.ts
@@ -3,6 +3,9 @@ export interface ExplorerChannelType {
 }
 
 /**
+ * @requires user - explorer 的預設使用者
+ * @requires pass - explorer 的預設密碼
+ * @requires port - explorer 的 port
  * @requires channels - channel 與 加入此 Channel 的 hostname
  */
 export interface ExplorerUpForMyOrgType{

--- a/src/model/yaml/docker-compose/explorerDockerComposeYaml.ts
+++ b/src/model/yaml/docker-compose/explorerDockerComposeYaml.ts
@@ -1,0 +1,71 @@
+import { Config } from '../../../config'
+import DockerComposeYaml from './dockerComposeYaml'
+
+class ExplorerDockerComposeYaml extends DockerComposeYaml {
+  constructor (config: Config) {
+    super()
+    this.addNetwork(config.networkName, { name: config.networkName, external: true })
+    this.addVolume(`explorerdb.${config.networkName}`, {})
+    this.addService(
+      `explorerdb.${config.networkName}`,
+      {
+        image: `hyperledger/explorer-db:${config.fabricVersion.explorerDb}`,
+        container_name: `explorerdb.${config.networkName}`,
+        hostname: `explorerdb.${config.networkName}`,
+        environment: [
+          'DATABASE_DATABASE=fabricexplorer',
+          'DATABASE_USERNAME=hppoc',
+          'DATABASE_PASSWORD=password',
+        ],
+        healthcheck: {
+          test: 'pg_isready -h localhost -p 5432 -q -U postgres',
+          interval: '30s',
+          timeout: '10s',
+          retries: 5,
+        },
+        volumes: [
+          `explorerdb.${config.networkName}:/var/lib/postgresql/data`,
+        ],
+        networks: [
+          config.networkName,
+        ],
+      },
+    )
+    this.addService(
+      `explorer.${config.networkName}`,
+      {
+        image: `hyperledger/explorer:${config.fabricVersion.explorer}`,
+        container_name: `explorer.${config.networkName}`,
+        hostname: `explorer.${config.networkName}`,
+        environment: [
+          `DATABASE_HOST=explorerdb.${config.networkName}`,
+          'DATABASE_DATABASE=fabricexplorer',
+          'DATABASE_USERNAME=hppoc',
+          'DATABASE_PASSWD=password',
+          'LOG_LEVEL_APP=debug',
+          'LOG_LEVEL_DB=debug',
+          'LOG_LEVEL_CONSOLE=info',
+          'LOG_CONSOLE_STDOUT=true',
+          'DISCOVERY_AS_LOCALHOST=false',
+        ],
+        volumes: [
+          `\${BDK_DOCKER_HOST_PATH:-~/.bdk}/${config.networkName}/fabric-explorer/config.json:/opt/explorer/app/platform/fabric/config.json`,
+          `\${BDK_DOCKER_HOST_PATH:-~/.bdk}/${config.networkName}/fabric-explorer/connection-profile:/opt/explorer/app/platform/fabric/connection-profile`,
+        ],
+        ports: [
+          '8080:8080',
+        ],
+        depends_on: {
+          [`explorerdb.${config.networkName}`]: {
+            condition: 'service_healthy',
+          },
+        },
+        networks: [
+          config.networkName,
+        ],
+      },
+    )
+  }
+}
+
+export default ExplorerDockerComposeYaml

--- a/src/model/yaml/docker-compose/explorerDockerComposeYaml.ts
+++ b/src/model/yaml/docker-compose/explorerDockerComposeYaml.ts
@@ -2,7 +2,7 @@ import { Config } from '../../../config'
 import DockerComposeYaml from './dockerComposeYaml'
 
 class ExplorerDockerComposeYaml extends DockerComposeYaml {
-  constructor (config: Config) {
+  constructor (config: Config, port: number = 8080) {
     super()
     this.addNetwork(config.networkName, { name: config.networkName, external: true })
     this.addVolume(`explorerdb.${config.networkName}`, {})
@@ -53,7 +53,7 @@ class ExplorerDockerComposeYaml extends DockerComposeYaml {
           `\${BDK_DOCKER_HOST_PATH:-~/.bdk}/${config.networkName}/fabric-explorer/connection-profile:/opt/explorer/app/platform/fabric/connection-profile`,
         ],
         ports: [
-          '8080:8080',
+          `${port}:8080`,
         ],
         depends_on: {
           [`explorerdb.${config.networkName}`]: {

--- a/src/model/yaml/explorer/explorerConfigYaml.ts
+++ b/src/model/yaml/explorer/explorerConfigYaml.ts
@@ -5,15 +5,15 @@ interface NetworkConfig {
   profile: string
 }
 
-interface Config {
+interface ExplorerConfigInterface {
   'network-configs': {
     [configName: string]: NetworkConfig
   }
   license: string
 }
 
-class ConfigYaml extends BdkYaml<Config> {
-  constructor (value?: Config) {
+class ExplorerConfigYaml extends BdkYaml<ExplorerConfigInterface> {
+  constructor (value?: ExplorerConfigInterface) {
     super(value)
     if (!value) {
       this.value.license = 'Apache-2.0'
@@ -38,4 +38,4 @@ class ConfigYaml extends BdkYaml<Config> {
   }
 }
 
-export default ConfigYaml
+export default ExplorerConfigYaml

--- a/src/model/yaml/explorer/explorerConnectionProfileYaml.ts
+++ b/src/model/yaml/explorer/explorerConnectionProfileYaml.ts
@@ -43,7 +43,7 @@ interface Peer {
   tlsCACerts: { pem: string }
 }
 
-interface ConnectionConfigInterface {
+interface ExplorerConnectionProfileInterface {
   name: string
   version: string
   client: Client
@@ -52,8 +52,8 @@ interface ConnectionConfigInterface {
   peers: {[peerName: string]: Peer}
 }
 
-class ConnectionProfileYaml extends BdkYaml<ConnectionConfigInterface> {
-  constructor (value?: ConnectionConfigInterface) {
+class ExplorerConnectionProfileYaml extends BdkYaml<ExplorerConnectionProfileInterface> {
+  constructor (value?: ExplorerConnectionProfileInterface) {
     super(value)
 
     this.value.version = value?.version || '1.0.0'
@@ -173,4 +173,4 @@ class ConnectionProfileYaml extends BdkYaml<ConnectionConfigInterface> {
   }
 }
 
-export default ConnectionProfileYaml
+export default ExplorerConnectionProfileYaml

--- a/src/model/yaml/explorer/explorerConnectionProfileYaml.ts
+++ b/src/model/yaml/explorer/explorerConnectionProfileYaml.ts
@@ -1,4 +1,5 @@
 import BdkYaml from '../bdkYaml'
+import ConnectionProfileYaml from '../network/connectionProfileYaml'
 
 interface Client {
   tlsEnable: boolean
@@ -97,6 +98,17 @@ class ExplorerConnectionProfileYaml extends BdkYaml<ExplorerConnectionProfileInt
 
   public setAdminCredential (id: string, password: string) {
     this.value.client.adminCredential = { id, password }
+  }
+
+  public loadFromPeerConnectionProfile (peerConnectProfile: ConnectionProfileYaml) {
+    Object.keys(peerConnectProfile.value.organizations).forEach(org => {
+      this.value.organizations[org] = {
+        ...peerConnectProfile.value.organizations[org],
+        adminPrivateKey: { pem: '' },
+        signedCert: { pem: '' },
+      }
+    })
+    this.value.peers = peerConnectProfile.value.peers
   }
 
   private addOrg (org: string) {

--- a/src/model/yaml/network/connectionProfileYaml.ts
+++ b/src/model/yaml/network/connectionProfileYaml.ts
@@ -39,7 +39,7 @@ interface CertificateAuthorities {
   }
 }
 
-interface ConnectionConfigInterface {
+interface ConnectionProfileInterface {
   name: string
   version: string
   client: Client
@@ -48,8 +48,8 @@ interface ConnectionConfigInterface {
   certificateAuthorities: {[caName: string]: CertificateAuthorities}
 }
 
-class ConnectionConfigYaml extends BdkYaml<ConnectionConfigInterface> {
-  constructor (value?: ConnectionConfigInterface) {
+class ConnectionProfileYaml extends BdkYaml<ConnectionProfileInterface> {
+  constructor (value?: ConnectionProfileInterface) {
     super(value)
 
     this.value.name = 'connection-config'
@@ -158,4 +158,4 @@ class ConnectionConfigYaml extends BdkYaml<ConnectionConfigInterface> {
   }
 }
 
-export default ConnectionConfigYaml
+export default ConnectionProfileYaml

--- a/src/model/yaml/network/connectionProfileYaml.ts
+++ b/src/model/yaml/network/connectionProfileYaml.ts
@@ -55,10 +55,10 @@ class ConnectionProfileYaml extends BdkYaml<ConnectionProfileInterface> {
     this.value.name = 'connection-config'
     this.value.version = '1.0.0'
 
-    this.setDefaultClient()
-    this.setDefaultOrganizations()
-    this.setDefaultPeers()
-    this.setDefaultCertificateAuthorities()
+    !value?.client && this.setDefaultClient()
+    !value?.organizations && this.setDefaultOrganizations()
+    !value?.peers && this.setDefaultPeers()
+    !value?.certificateAuthorities && this.setDefaultCertificateAuthorities()
   }
 
   private setDefaultClient () {

--- a/src/service/explorer.ts
+++ b/src/service/explorer.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import { logger } from '../util/logger'
 import { ExplorerConfigType, ExplorerUpForMyOrgType } from '../model/type/explorer.type'
 import ExplorerConnectionProfileYaml from '../model/yaml/explorer/explorerConnectionProfileYaml'
-import ExplorerConfig from '../model/yaml/explorer/config'
+import ExplorerConfigYaml from '../model/yaml/explorer/explorerConfigYaml'
 import DockerComposeYaml from '../model/yaml/docker-compose/dockerComposeYaml'
 import BdkFile from '../instance/bdkFile'
 import Channel from './channel'
@@ -68,7 +68,7 @@ export default class Explorer extends AbstractService {
   public async up (data: ExplorerConfigType[]): Promise<InfraRunnerResultType> {
     logger.info('[*] Blockchain Explorer up')
 
-    const configJson = new ExplorerConfig()
+    const configJson = new ExplorerConfigYaml()
 
     // * clear config file
     this.initializeFolder()
@@ -158,7 +158,7 @@ export default class Explorer extends AbstractService {
   /** @ignore */
   private updateConfigNetwork (data: ExplorerConfigType) {
     logger.info(`[*] Blockchain Explorer update network ${data.networkName} config`)
-    const configJson = new ExplorerConfig(JSON.parse(fs.readFileSync(`${this.hostBasePath}/config.json`).toString()))
+    const configJson = new ExplorerConfigYaml(JSON.parse(fs.readFileSync(`${this.hostBasePath}/config.json`).toString()))
     if (!configJson.getNetworkList().includes(data.networkName)) {
       configJson.addNetwork(data.networkName)
       fs.writeFileSync(`${this.hostBasePath}/config.json`, configJson.getJsonString())

--- a/src/service/explorer.ts
+++ b/src/service/explorer.ts
@@ -1,141 +1,58 @@
-import fs from 'fs'
 import { logger } from '../util/logger'
-import { ExplorerConfigType, ExplorerUpForMyOrgType } from '../model/type/explorer.type'
+import { ExplorerUpForMyOrgType } from '../model/type/explorer.type'
 import ExplorerConnectionProfileYaml from '../model/yaml/explorer/explorerConnectionProfileYaml'
 import ExplorerConfigYaml from '../model/yaml/explorer/explorerConfigYaml'
-import BdkFile from '../instance/bdkFile'
 import Channel from './channel'
 import ExplorerInstance from '../instance/explorer'
 import { DockerResultType, InfraRunnerResultType } from '../instance/infra/InfraRunner.interface'
 import { AbstractService, ParserType } from './Service.abstract'
-import { Config } from '../config'
 import ExplorerDockerComposeYaml from '../model/yaml/docker-compose/explorerDockerComposeYaml'
 
 interface ExplorerParser extends ParserType {
-  listJoinedChannel: (result: DockerResultType) => string[]
+  listJoinedChannel: (result: DockerResultType, options: {hostname: string}) => {[channelName: string]: {hostname: string}}
 }
 
 // TODO refactor
 export default class Explorer extends AbstractService {
   static readonly parser: ExplorerParser = {
-    listJoinedChannel: Channel.parser.listJoinedChannel,
+    listJoinedChannel: (result, options) => {
+      const joinedChannel = Channel.parser.listJoinedChannel(result)
+      const channels: {[channelName: string]: {hostname: string}} = {}
+      joinedChannel.forEach(channel => {
+        channels[channel] = { hostname: options.hostname }
+      })
+      return channels
+    },
   }
 
   /** @ignore */
-  private hostBasePath: string
-
-  /** @ignore */
-  private dockerNetwork: string
-
-  /** @ignore */
-  private fabricExplorerVer: string
-
-  /** @ignore */
-  private fabricExplorerDbVer: string
-
-  constructor (config: Config) {
-    super(config)
-    this.hostBasePath = this.bdkFile.getExplorerRootFilePath()
-    // TODO: explorer應該要能跨network
-    this.dockerNetwork = this.config.networkName
-    this.fabricExplorerVer = this.config.fabricVersion.explorer
-    this.fabricExplorerDbVer = this.config.fabricVersion.explorerDb
-  }
-
-  /**
-   * @ignore
-   * @description Clear explorer Folder
-   */
-  private clearFolder () {
-    if (fs.existsSync(`${this.hostBasePath}`)) {
-      logger.info('[*] Clear workspace: remove old env file')
-      fs.rmdirSync(`${this.hostBasePath}`, { recursive: true })
+  private createExplorerConfig (data: ExplorerUpForMyOrgType) {
+    logger.info(`[*] Create file: ${this.config.networkName}.json`)
+    const explorerConnectionProfileYaml = new ExplorerConnectionProfileYaml()
+    explorerConnectionProfileYaml.setName(this.config.networkName)
+    explorerConnectionProfileYaml.loadFromPeerConnectionProfile(this.bdkFile.getConnectionFile(this.config.orgName, this.config.orgDomainName))
+    explorerConnectionProfileYaml.setOrgKey(
+      this.config.orgName,
+      this.bdkFile.getAdminPrivateKeyPem(this.config.orgDomainName),
+      this.bdkFile.getAdminSignCert(this.config.orgDomainName),
+    )
+    if (data.channels) {
+      Object.keys(data.channels).forEach(channel => {
+        explorerConnectionProfileYaml.addChannel(
+          channel,
+          [`${data.channels?.[channel].hostname}.${this.config.orgDomainName}`],
+        )
+      })
     }
-  }
+    explorerConnectionProfileYaml.setClientOrganization(this.config.orgName)
+    this.bdkFile.createExplorerConnectionProfile(this.config.networkName, explorerConnectionProfileYaml)
 
-  /**
-   * @ignore
-   * @description Initialize Folder
-   */
-  private initializeFolder () {
-    this.clearFolder()
-    fs.mkdirSync(`${this.hostBasePath}/connection-profile`, { recursive: true })
-  }
-
-  /**
-   * @description 啟動 explorer
-   */
-  public async up (data: ExplorerConfigType[]): Promise<InfraRunnerResultType> {
-    logger.info('[*] Blockchain Explorer up')
-
-    const configJson = new ExplorerConfigYaml()
-
-    // * clear config file
-    this.initializeFolder()
-    data.forEach(explorerConfig => {
-      logger.info(`[*] Create file: ${explorerConfig.networkName}.json`)
-      this.createConnectProfileYaml(explorerConfig)
-      configJson.addNetwork(explorerConfig.networkName)
-    })
+    logger.info(`[*] Blockchain Explorer create network ${this.config.networkName} config`)
+    const explorerConfigYaml = new ExplorerConfigYaml()
+    explorerConfigYaml.addNetwork(this.config.networkName)
 
     logger.info('[*] Create file: config.json')
-
-    fs.writeFileSync(`${this.hostBasePath}/config.json`, configJson.getJsonString())
-
-    logger.info('[*] Create file: docker-compose.yaml')
-    const dockerComposeYaml = new ExplorerDockerComposeYaml(this.config)
-    this.bdkFile.createExplorerDockerComposeYaml(dockerComposeYaml)
-
-    logger.info('[*] Starting explorer container')
-
-    return await (new ExplorerInstance(this.config, this.infra)).up()
-  }
-
-  /** @ignore */
-  private updateConfigNetwork (data: ExplorerConfigType) {
-    logger.info(`[*] Blockchain Explorer update network ${data.networkName} config`)
-    const configJson = new ExplorerConfigYaml(JSON.parse(fs.readFileSync(`${this.hostBasePath}/config.json`).toString()))
-    if (!configJson.getNetworkList().includes(data.networkName)) {
-      configJson.addNetwork(data.networkName)
-      fs.writeFileSync(`${this.hostBasePath}/config.json`, configJson.getJsonString())
-    }
-    this.createConnectProfileYaml(data)
-  }
-
-  /** @ignore */
-  private createConnectProfileYaml (explorerConfig: ExplorerConfigType) {
-    const rootFilePath = (new BdkFile(this.config, explorerConfig.networkName)).getRootFilePath()
-    const explorerConnectProfileYaml = new ExplorerConnectionProfileYaml()
-
-    explorerConnectProfileYaml.setName(explorerConfig.networkName)
-    Object.keys(explorerConfig.orgs).forEach(org => {
-      explorerConfig.orgs[org].peers.forEach(peer => {
-        explorerConnectProfileYaml.addPeer(
-          org,
-          peer.url,
-          fs.readFileSync(`${rootFilePath}/tlsca/${peer.url}/ca.crt`).toString(),
-          peer.port)
-      })
-      explorerConnectProfileYaml.setOrgKey(
-        org,
-        this.bdkFile.getAdminPrivateKeyPem(explorerConfig.orgs[org].domain),
-        this.bdkFile.getAdminSignCert(explorerConfig.orgs[org].domain),
-      )
-    })
-    Object.keys(explorerConfig.channels).forEach(channel => {
-      explorerConnectProfileYaml.addChannel(
-        channel,
-        explorerConfig.channels[channel].orgs.reduce((accumulator, org) => (accumulator.concat(explorerConfig.orgs[org].peers.map(x => x.url))), [] as string[]),
-      )
-    })
-    explorerConnectProfileYaml.setClientOrganization(explorerConfig.clientOrganization)
-    const networkJSONStr = explorerConnectProfileYaml.getJsonString()
-    // const networkJSONStrOld = JSON.stringify(networkJson(config))
-
-    fs.writeFileSync(
-      `${this.hostBasePath}/connection-profile/${explorerConfig.networkName}.json`,
-      networkJSONStr,
-    )
+    this.bdkFile.createExplorerConfig(explorerConfigYaml)
   }
 
   /**
@@ -146,33 +63,17 @@ export default class Explorer extends AbstractService {
     return await (new ExplorerInstance(this.config, this.infra)).down()
   }
 
-  /** @ignore */
-  private getExplorerConfig (peersAddress: string, orgDomainName: string, channel: string[]): ExplorerConfigType {
-    return ({
-      networkName: this.config.networkName,
-      orgs: {
-        [this.config.orgName]: {
-          domain: orgDomainName,
-          peers: [{ url: peersAddress.split(':')[0], port: parseInt(peersAddress.split(':')[1], 10) },
-          ],
-        },
-      },
-      clientOrganization: this.config.orgName,
-      channels: (channel.reduce((accumulator: {[channelName: string]: {orgs: string[]}}, currentValue) => ({ ...accumulator, [currentValue]: { orgs: [this.config.orgName] } }), {})),
-    })
-  }
-
   /**
    * @description 啟動 peer org 的 explorer
    */
-  public async upForMyOrg (payload: ExplorerUpForMyOrgType): Promise<void> {
+  public async upForMyOrg (): Promise<void> {
     const listJoinedChannelResult = await this.upForMyOrgSteps().listJoinedChannel()
     if (!('stdout' in listJoinedChannelResult)) {
       logger.error('this service only for docker infra')
       throw new Error('this service for docker infra')
     }
-    const joinedChannel = Explorer.parser.listJoinedChannel(listJoinedChannelResult)
-    await this.upForMyOrgSteps().up({ ...payload, joinedChannel })
+    const channels = Explorer.parser.listJoinedChannel(listJoinedChannelResult, { hostname: this.config.hostname })
+    await this.upForMyOrgSteps().up({ channels })
   }
 
   /**
@@ -186,8 +87,11 @@ export default class Explorer extends AbstractService {
       },
       up: async (payload: ExplorerUpForMyOrgType): Promise<InfraRunnerResultType> => {
         logger.info('[*] up explorer for my org step 2 (start explorer)')
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return await this.up([this.getExplorerConfig(payload.peerAddress, this.config.orgDomainName, payload.joinedChannel!)])
+        this.createExplorerConfig(payload)
+        const dockerComposeYaml = new ExplorerDockerComposeYaml(this.config)
+        this.bdkFile.createExplorerDockerComposeYaml(dockerComposeYaml)
+        logger.info('[*] Starting explorer container')
+        return await (new ExplorerInstance(this.config, this.infra)).up()
       },
     }
   }
@@ -195,14 +99,14 @@ export default class Explorer extends AbstractService {
   /**
    * @description 更新 explorer 的 peer org
    */
-  public async updateForMyOrg (payload: ExplorerUpForMyOrgType): Promise<void> {
+  public async updateForMyOrg (): Promise<void> {
     const listJoinedChannelResult = await this.updateForMyOrgSteps().listJoinedChannel()
     if (!('stdout' in listJoinedChannelResult)) {
       logger.error('this service only for docker infra')
       throw new Error('this service for docker infra')
     }
-    const joinedChannel = Explorer.parser.listJoinedChannel(listJoinedChannelResult)
-    await this.updateForMyOrgSteps().restart({ ...payload, joinedChannel })
+    const channels = Explorer.parser.listJoinedChannel(listJoinedChannelResult, { hostname: this.config.hostname })
+    await this.updateForMyOrgSteps().restart({ channels })
   }
 
   /**
@@ -216,8 +120,7 @@ export default class Explorer extends AbstractService {
       },
       restart: async (payload: ExplorerUpForMyOrgType): Promise<InfraRunnerResultType> => {
         logger.info('[*] update explorer for my org step 2 (restart explorer)')
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.updateConfigNetwork(this.getExplorerConfig(payload.peerAddress, this.config.orgDomainName, payload.joinedChannel!))
+        this.createExplorerConfig(payload)
         return await (new ExplorerInstance(this.config, this.infra)).restart()
       },
     }

--- a/src/service/explorer.ts
+++ b/src/service/explorer.ts
@@ -182,8 +182,8 @@ export default class Explorer extends AbstractService {
       })
       explorerConnectProfileYaml.setOrgKey(
         org,
-        fs.readFileSync(`${rootFilePath}/peerOrganizations/${explorerConfig.orgs[org].domain}/users/Admin@${explorerConfig.orgs[org].domain}/msp/keystore/priv_sk`).toString(),
-        fs.readFileSync(`${rootFilePath}/peerOrganizations/${explorerConfig.orgs[org].domain}/users/Admin@${explorerConfig.orgs[org].domain}/msp/signcerts/Admin@${explorerConfig.orgs[org].domain}-cert.pem`).toString(),
+        this.bdkFile.getAdminPrivateKeyPem(explorerConfig.orgs[org].domain),
+        this.bdkFile.getAdminSignCert(explorerConfig.orgs[org].domain),
       )
     })
     Object.keys(explorerConfig.channels).forEach(channel => {

--- a/src/service/explorer.ts
+++ b/src/service/explorer.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { logger } from '../util/logger'
 import { ExplorerConfigType, ExplorerUpForMyOrgType } from '../model/type/explorer.type'
-import ConnectProfileYaml from '../model/yaml/explorer/connectProfileYaml.ts'
+import ExplorerConnectionProfileYaml from '../model/yaml/explorer/explorerConnectionProfileYaml'
 import ExplorerConfig from '../model/yaml/explorer/config'
 import DockerComposeYaml from '../model/yaml/docker-compose/dockerComposeYaml'
 import BdkFile from '../instance/bdkFile'
@@ -169,31 +169,31 @@ export default class Explorer extends AbstractService {
   /** @ignore */
   private createConnectProfileYaml (explorerConfig: ExplorerConfigType) {
     const rootFilePath = (new BdkFile(this.config, explorerConfig.networkName)).getRootFilePath()
-    const connectProfileYaml = new ConnectProfileYaml()
+    const explorerConnectProfileYaml = new ExplorerConnectionProfileYaml()
 
-    connectProfileYaml.setName(explorerConfig.networkName)
+    explorerConnectProfileYaml.setName(explorerConfig.networkName)
     Object.keys(explorerConfig.orgs).forEach(org => {
       explorerConfig.orgs[org].peers.forEach(peer => {
-        connectProfileYaml.addPeer(
+        explorerConnectProfileYaml.addPeer(
           org,
           peer.url,
           fs.readFileSync(`${rootFilePath}/tlsca/${peer.url}/ca.crt`).toString(),
           peer.port)
       })
-      connectProfileYaml.setOrgKey(
+      explorerConnectProfileYaml.setOrgKey(
         org,
         fs.readFileSync(`${rootFilePath}/peerOrganizations/${explorerConfig.orgs[org].domain}/users/Admin@${explorerConfig.orgs[org].domain}/msp/keystore/priv_sk`).toString(),
         fs.readFileSync(`${rootFilePath}/peerOrganizations/${explorerConfig.orgs[org].domain}/users/Admin@${explorerConfig.orgs[org].domain}/msp/signcerts/Admin@${explorerConfig.orgs[org].domain}-cert.pem`).toString(),
       )
     })
     Object.keys(explorerConfig.channels).forEach(channel => {
-      connectProfileYaml.addChannel(
+      explorerConnectProfileYaml.addChannel(
         channel,
         explorerConfig.channels[channel].orgs.reduce((accumulator, org) => (accumulator.concat(explorerConfig.orgs[org].peers.map(x => x.url))), [] as string[]),
       )
     })
-    connectProfileYaml.setClientOrganization(explorerConfig.clientOrganization)
-    const networkJSONStr = connectProfileYaml.getJsonString()
+    explorerConnectProfileYaml.setClientOrganization(explorerConfig.clientOrganization)
+    const networkJSONStr = explorerConnectProfileYaml.getJsonString()
     // const networkJSONStrOld = JSON.stringify(networkJson(config))
 
     fs.writeFileSync(

--- a/src/service/network.ts
+++ b/src/service/network.ts
@@ -107,14 +107,14 @@ export default class Network extends AbstractService {
    * @description 產生 blockahin network 的連線設定 yaml 檔案
    * @returns blockchain network 連線設定的 yaml 檔案（在 ~/.bdk/[blockchain network 名稱]/peerOrganizations/[domain 的名稱]/connection-[peer org 的名稱].yaml）
    */
-  public createConnectionConfig (dto: NetworkCreateType) {
+  public createConnectionProfile (dto: NetworkCreateType) {
     logger.info(`[*] Network create connection config profile: ${this.config.networkName}`)
 
     if (dto.peerOrgs === undefined) {
       throw new ParamsError('Invalid params: Required parameter <peerOrgs> missing')
     }
 
-    (new Peer(this.config, this.infra)).createConnectionConfigYaml(dto)
+    (new Peer(this.config, this.infra)).createConnectionProfileYaml(dto)
   }
 
   /**

--- a/src/service/peer.ts
+++ b/src/service/peer.ts
@@ -4,7 +4,7 @@ import { NetworkCryptoConfigPeerOrgType, NetworkCreatePeerOrgType, NetworkPeerPo
 import CryptoConfigYaml from '../model/yaml/network/cryptoConfigYaml'
 import PeerDockerComposeYaml from '../model/yaml/docker-compose/peerDockerComposeYaml'
 import PeerInstance from '../instance/peer'
-import ConnectionConfigYaml from '../model/yaml/network/connectionConfigYaml'
+import ConnectionProfileYaml from '../model/yaml/network/connectionProfileYaml'
 import { InstanceTypeEnum } from '../instance/bdkFile'
 import ConfigtxYaml from '../model/yaml/network/configtx'
 import FabricTools from '../instance/fabricTools'
@@ -97,13 +97,13 @@ export default class Peer extends AbstractService {
     const { peerOrgs } = dto
     peerOrgs.forEach((peerOrg) => {
       logger.info(`[*] Peer create connection config: ${peerOrg.name}`)
-      const connectionConfigYaml = new ConnectionConfigYaml()
+      const connectionProfileYaml = new ConnectionProfileYaml()
 
-      connectionConfigYaml.setName(`${this.config.networkName}-${peerOrg.name}`)
-      connectionConfigYaml.setClientOrganization(peerOrg.name)
+      connectionProfileYaml.setName(`${this.config.networkName}-${peerOrg.name}`)
+      connectionProfileYaml.setClientOrganization(peerOrg.name)
 
       for (let i = 0; i < peerOrg.peerCount; i++) {
-        connectionConfigYaml.addPeer(
+        connectionProfileYaml.addPeer(
           peerOrg.name,
           `peer${i}.${peerOrg.domain}`,
           this.bdkFile.getPeerOrgTlsCertString(i, peerOrg.domain),
@@ -111,7 +111,7 @@ export default class Peer extends AbstractService {
         )
       }
 
-      this.bdkFile.createConnectionFile(peerOrg.name, peerOrg.domain, connectionConfigYaml)
+      this.bdkFile.createConnectionFile(peerOrg.name, peerOrg.domain, connectionProfileYaml)
     })
   }
 

--- a/src/service/peer.ts
+++ b/src/service/peer.ts
@@ -93,7 +93,7 @@ export default class Peer extends AbstractService {
    * @description 產生 peer org 的連線設定 yaml 檔案
    * @returns peer org 連線設定的 yaml 檔案（在 ~/.bdk/[blockchain network 名稱]/peerOrganizations/[domain 的名稱]/connection-[peer org 的名稱].yaml）
    */
-  public createConnectionConfigYaml (dto: OrgPeerCreateType) {
+  public createConnectionProfileYaml (dto: OrgPeerCreateType) {
     const { peerOrgs } = dto
     peerOrgs.forEach((peerOrg) => {
       logger.info(`[*] Peer create connection config: ${peerOrg.name}`)


### PR DESCRIPTION
# PULL REQUEST

## 說明 (Description)

1. 修正「使用 CA 建立的網路無法使用 explorer 」的問題
2. cp up 時允許輸入 user/pass/port
3. rename `connectionConfig` to `connectionProfile`
[connection profile是官方名詞](https://hyperledger-fabric.readthedocs.io/en/release-2.2/developapps/connectionprofile.html
)
## 相關問題 (Linked Issues)
- 使用 CA 建立的網路無法使用 explorer 

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [x] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS:
* NodeJS Version:
* NPM Version:
* Docker Version:

## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [x] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [x] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [x] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [x] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [x] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
