### PR TITLE
fix: quorum consensus and explorer

### DIFF
--- a/src/quorum/command/explorer/create.ts
+++ b/src/quorum/command/explorer/create.ts
@@ -4,6 +4,8 @@ import { onCancel } from '../../../util/error'
 import config from '../../config'
 import prompts from 'prompts'
 import ora from 'ora'
+import { ExplorerCreateType } from '../../model/type/explorer.type'
+import Backup from '../../service/backup'
 
 export const command = 'create'
 
@@ -21,10 +23,35 @@ export const builder = (yargs: Argv<OptType>) => {
 
 export const handler = async (argv: Arguments<OptType>) => {
   const explorer = new Explorer(config)
+  const backup = new Backup(config)
 
-  const explorerCreate: number = await (async () => {
+  const getBackupItems = backup.getExportItems()
+  const explorerCreate: ExplorerCreateType = await (async () => {
     if (argv.interactive) {
       return (await prompts([
+        {
+          type: 'select',
+          name: 'httpModeEnabled',
+          message: 'What is the connect mode you want?',
+          choices: [
+            {
+              title: 'ipc mode',
+              value: false,
+            },
+            {
+              title: 'http mode',
+              value: true,
+            },
+          ],
+          initial: 0,
+        },
+        {
+          type: 'select',
+          name: 'nodeName',
+          message: 'What is the host node of quorum explorer?',
+          choices: getBackupItems,
+          initial: 0,
+        },
         {
           type: 'number',
           name: 'port',
@@ -33,13 +60,17 @@ export const handler = async (argv: Arguments<OptType>) => {
           max: 65535,
           initial: 26000,
         },
-      ], { onCancel })).port
+      ], { onCancel })) as ExplorerCreateType
     } else {
-      return 26000
+      return {
+        httpModeEnabled: false,
+        nodeName: getBackupItems[0].value,
+        port: 26000,
+      }
     }
   })()
 
   const spinner = ora('Quorum Explorer Create ...').start()
   await explorer.create(explorerCreate)
-  spinner.succeed(`Quorum Explorer Create Successfully! Host at: http://localhost:${explorerCreate}`)
+  spinner.succeed(`Quorum Explorer Create Successfully! Host at: http://localhost:${explorerCreate.port}`)
 }

--- a/src/quorum/model/type/explorer.type.ts
+++ b/src/quorum/model/type/explorer.type.ts
@@ -3,6 +3,18 @@ export interface ExplorerChannelType {
 }
 
 /**
+ * @requires bdkPath - explorer 的 bdk 路徑
+ * @requires httpModeEnabled - 是否啟用 http 模式
+ * @requires nodeName - explorer 使用的節點名稱
+ * @requires port - explorer 的 port
+ */
+export interface ExplorerCreateType {
+  httpModeEnabled: boolean
+  nodeName: string
+  port: number
+}
+
+/**
  * @requires user - explorer 的預設使用者
  * @requires pass - explorer 的預設密碼
  * @requires port - explorer 的 port

--- a/src/quorum/model/yaml/docker-compose/memberDockerCompose.ts
+++ b/src/quorum/model/yaml/docker-compose/memberDockerCompose.ts
@@ -4,7 +4,7 @@ class MemberDockerComposeYaml extends DockerComposeYaml {
   public addMember (bdkPath: string, memberNum: number, rpcPort: number, chainId: number, peerPort: number) {
     this.addNetwork('quorum', {})
     this.addService(`member${memberNum}`, {
-      image: 'quorumengineering/quorum:22.7.4',
+      image: 'quorumengineering/quorum:23.4.0',
       // eslint-disable-next-line no-template-curly-in-string
       user: '${UID}:${GID}',
       container_name: `member${memberNum}`,

--- a/src/quorum/model/yaml/docker-compose/validatorDockerComposeYaml.ts
+++ b/src/quorum/model/yaml/docker-compose/validatorDockerComposeYaml.ts
@@ -4,7 +4,7 @@ class ValidatorDockerComposeYaml extends DockerComposeYaml {
   public addValidator (bdkPath: string, validatorNum: number, rpcPort: number, chainId: number, peerPort: number) {
     this.addNetwork('quorum', {})
     this.addService(`validator${validatorNum}`, {
-      image: 'quorumengineering/quorum:22.7.4',
+      image: 'quorumengineering/quorum:23.4.0',
       // eslint-disable-next-line no-template-curly-in-string
       user: '${UID}:${GID}',
       container_name: `validator${validatorNum}`,

--- a/src/quorum/service/explorer.ts
+++ b/src/quorum/service/explorer.ts
@@ -2,14 +2,15 @@ import { logger } from '../../util'
 import { AbstractService } from './Service.abstract'
 import ExplorerInstance from '../instance/explorer'
 import ExplorerDockerComposeYaml from '../model/yaml/docker-compose/explorerDockerComposeYaml'
+import { ExplorerCreateType } from '../model/type/explorer.type'
 
 export default class Explorer extends AbstractService {
   /**
    * @description 啟動 explorer
    */
-  public async create (port: number) {
-    logger.debug(`Explorer up: ${port}`)
-    this.createExplorerDockerCompose(port)
+  public async create (payload: ExplorerCreateType) {
+    logger.debug(`Explorer up: ${payload.port}`)
+    this.createExplorerDockerCompose(payload)
     logger.debug('Starting explorer container')
     return await (new ExplorerInstance(this.config, this.infra).up())
   }
@@ -19,8 +20,13 @@ export default class Explorer extends AbstractService {
     this.removeBdkFiles(this.getExplorerFiles())
   }
 
-  private createExplorerDockerCompose (port: number) {
-    const explorerDockerComposeYaml = new ExplorerDockerComposeYaml(this.bdkFile.getBdkPath(), port)
+  private createExplorerDockerCompose (payload: ExplorerCreateType) {
+    const explorerDockerComposeYaml = new ExplorerDockerComposeYaml(
+      this.bdkFile.getBdkPath(),
+      payload.httpModeEnabled,
+      payload.nodeName,
+      payload.port,
+    )
     this.bdkFile.createExplorerDockerComposeYaml(explorerDockerComposeYaml)
   }
 

--- a/src/quorum/service/network.ts
+++ b/src/quorum/service/network.ts
@@ -505,7 +505,7 @@ export default class Network extends AbstractService {
       autoRemove: true,
       user: false,
       image: 'quorumengineering/quorum',
-      tag: '22.7.4',
+      tag: '23.4.0',
       volumes: [`${this.bdkFile.getBdkPath()}/${option}/data/geth.ipc:/root/geth.ipc`],
       commands: [
         'attach',

--- a/test/quorum/service/explorer.test.ts
+++ b/test/quorum/service/explorer.test.ts
@@ -4,6 +4,7 @@ import assert from 'assert'
 import Network from '../../../src/quorum/service/network'
 import Explorer from '../../../src/quorum/service/explorer'
 import config from '../../../src/quorum/config'
+import { ExplorerCreateType } from '../../../src/quorum/model/type/explorer.type'
 
 describe('Quorum.Explorer.Service', function () {
   this.timeout(600000)
@@ -12,13 +13,17 @@ describe('Quorum.Explorer.Service', function () {
   const dockerdOption = { all: true }
   const network = new Network(config)
   const explorer = new Explorer(config)
-  const port = 9000
+  const explorerCreateOptions: ExplorerCreateType = {
+    httpModeEnabled: false,
+    nodeName: 'validator0',
+    port: 9000,
+  }
 
   describe('Quorum.Explorer.create', () => {
     it('should create and start the explorer', async () => {
       const initContainers = await docker.listContainers(dockerdOption)
       await network.createBdkFolder()
-      await explorer.create(port)
+      await explorer.create(explorerCreateOptions)
       const upContainers = await docker.listContainers(dockerdOption)
 
       assert.strictEqual(upContainers.length, initContainers.length + 2)


### PR DESCRIPTION
# PULL REQUEST

## 說明 (Description)

1. upgrade quorumengineering/quorum to version 23.4.0
2. add quorum explorer support member nodes (only in same machine)
3. if this issue still appear, maybe need to disable emptyBlock option

## 相關問題 (Linked Issues)

- https://github.com/Consensys/quorum/issues/1612
- https://github.com/Consensys/quorum/issues/1630

## 貢獻種類 (Type of change)

- [X] Bug fix (除錯 non-breaking change which fixes an issue)
- [ ] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS: macOS 13.4.1(c)
* NodeJS Version: v16.13.2
* NPM Version: v8.1.2
* Docker Version: 24.0.5

## 檢查清單 (Checklist):

- [X] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [ ] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [X] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [X] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [X] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [X] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [X] 同意 (I consent)
