### PR TITLE
fix: ui experience and response latency

### DIFF
--- a/src/ui/components/dockerlogs.tsx
+++ b/src/ui/components/dockerlogs.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Text, Box } from 'ink'
+import { Text, Box, Newline } from 'ink'
 import Docker from 'dockerode'
 
 export default function DockerLogs () {
@@ -35,7 +35,10 @@ export default function DockerLogs () {
           <Text>Image: {container.Image}</Text>
           <Text>Name: {container.Names.join(', ')}</Text>
           <Text>Status: {container.Status}</Text>
+          <Text>State: {container.State}</Text>
+          <Text>Created: {container.Created}</Text>
           {/* <Text>Ports: {container.Ports.map((port:any) => `${port.PrivatePort}:${port.PublicPort}`).join(', ')}</Text> */}
+          <Newline/>
         </Box>
       ))}
     </Box>

--- a/src/ui/components/selectInput.tsx
+++ b/src/ui/components/selectInput.tsx
@@ -3,9 +3,10 @@ import { Text, Box } from 'ink'
 import SelectInput from 'ink-select-input'
 import CommandContext from '../services/commandContext'
 
-export default function Select ({ setNetworkType }:any) {
+export default function Select ({ setNetworkType }: any) {
   const commandContext = new CommandContext()
 
+  const [isCommandExecuting, setIsCommandExecuting] = useState(false)
   const [items, setItems] = useState([
     {
       label: 'Fabric',
@@ -21,11 +22,16 @@ export default function Select ({ setNetworkType }:any) {
     setNetworkType(item.value)
   }
 
-  const handleCommand = (item: any) => {
-    const commandList = commandContext.makeItem(item.value)
+  const handleCommand = async (item: any) => {
+    if (isCommandExecuting) return
+    setIsCommandExecuting(true)
+    await new Promise(resolve => setImmediate(resolve))
+
+    const commandList = await commandContext.makeItem(item.value)
     if (commandList.length === 0) {
-      commandContext.executeCommand(item.value)
+      await commandContext.executeCommand(item.value)
     } else setItems(commandList)
+    setIsCommandExecuting(false)
   }
 
   return (
@@ -34,7 +40,7 @@ export default function Select ({ setNetworkType }:any) {
 
         <Text color={'white'} bold>Choose a type of network to deploy:</Text>
         <Box marginTop={1}>
-          <SelectInput items={items} onHighlight={selectChain} onSelect={handleCommand}/>
+          <SelectInput items={items} onHighlight={selectChain} onSelect={handleCommand} />
         </Box>
       </Box>
     </>

--- a/src/ui/components/terminal.tsx
+++ b/src/ui/components/terminal.tsx
@@ -8,7 +8,13 @@ export default function Terminal (props: TerminalProps) {
   const commandContext = new CommandContext()
   const [output, setOutput] = useState('')
   useEffect(() => {
-    setOutput(commandContext.getCommandHelp(props.type))
+    const fetchCommandHelp = async () => {
+      const result = await commandContext.getCommandHelp(props.type)
+      setOutput(result)
+    }
+    fetchCommandHelp().catch((err) => {
+      console.log(err)
+    })
   }, [props.type])
 
   return (

--- a/src/ui/services/commandContext.ts
+++ b/src/ui/services/commandContext.ts
@@ -1,39 +1,57 @@
-import { execSync } from 'child_process'
+import { exec, execSync } from 'child_process'
 import { ItemProps } from '../models/type/ui.type'
 
 export default class CommandContext {
-  public getCommandContext (command: string): (string|undefined)[] {
-    const text = execSync(`${command} --help`).toString()
+  public getCommandContext (command: string): Promise<(string | undefined)[]> {
+    return new Promise((resolve, reject) => {
+      exec(`${command} --help`, (error, stdout) => {
+        if (error) {
+          reject(error.message)
+          return
+        }
 
-    const regex = /(?::|：|คอมมาน)\n((?:\s+.*\n)+)/
-    const match = regex.exec(text)
+        const regex = /(?::|：|คอมมาน)\n((?:\s+.*\n)+)/
+        const match = regex.exec(stdout.toString())
 
-    const commandsRegex = this.makeRegex(command)
-    if (match) {
-      const commandsText = match[1]
-      const commands = commandsText.match(commandsRegex)
-        ?.map((match) => `${command} ${match.trim().split(/\s+/).pop()}`) ?? []
-      return commands
-    }
-    return []
+        const commandsRegex = this.makeRegex(command)
+        if (match) {
+          const commandsText = match[1]
+          const commands = commandsText.match(commandsRegex)
+            ?.map((match) => `${command} ${match.trim().split(/\s+/).pop()}`) ?? []
+          resolve(commands)
+        } else {
+          resolve([])
+        }
+      })
+    })
   }
 
-  public getCommandHelp (command: string): string {
-    const output = execSync(`${command} --help`).toString()
-    return output
+  public getCommandHelp (command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      exec(`${command} --help`, (error, stdout) => {
+        if (error) {
+          reject(error.message)
+          return
+        }
+        resolve(stdout.toString())
+      })
+    })
   }
 
-  public executeCommand (command: string): string {
-    // @TODO: support interactive mode
-    // if (this.checkInteractive(command)) {
-    //   output = execSync(`${command} --interactive`).toString()
-    // }
-    const output = execSync(command).toString()
-    return output
+  public executeCommand (command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      exec(command, (error, stdout) => {
+        if (error) {
+          reject(error.message)
+          return
+        }
+        resolve(stdout.toString())
+      })
+    })
   }
 
-  public makeItem (command: string): ItemProps[] {
-    const commands = this.getCommandContext(command)
+  public async makeItem (command: string): Promise<ItemProps[]> {
+    const commands = await this.getCommandContext(command)
     // map commands to key value pair and ignore undefined
     const items = commands.map((command) => {
       if (command) return { label: command, value: command }

--- a/src/ui/views/app.tsx
+++ b/src/ui/views/app.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import { Box, Text, useApp, useInput, useStdout } from 'ink'
 import Logo from '../components/logo'
-import Select from '../components/selectInput'
-import Option from '../components/option'
 import DockerLogs from '../components/dockerlogs'
+import Option from '../components/option'
+import Select from '../components/selectInput'
 
 export default function App () {
   const { exit } = useApp()
@@ -61,7 +61,7 @@ export default function App () {
       </Box>
       <Box width="55%" flexDirection='column'>
         <Box height="30%" flexDirection='row'>
-          <Select networkType={networkType} setNetworkType={setNetworkType} />
+          <Select setNetworkType={setNetworkType} />
           <Logo />
         </Box>
         <Box height="70%" borderStyle='bold' borderColor={'white'} flexDirection='column'>


### PR DESCRIPTION
# PULL REQUEST

## Before 
<!-- Please check the one that applies to this PR using "x". -->
- [x] 遵守 Commit 規範 (follow [commit convention](https://github.com/cathayddt/bdk/blob/master/.github/COMMIT_CONVENTION.md))
- [x] 遵守 Contributing 規範 (follow [contributing](https://github.com/cathayddt/bdk/blob/master/.github/CONTRIBUTING.md))

## 說明 (Description)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!--請簡單說明此PR的更動、被修復的問題以及相關的原因，並請列出這個更動所需要的任何相依模組/套件。

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->
Solve bdk ui selectInput latency. use asynchronous to resolve the problem!

In `src/ui/services/commandContext` CommandText class getCommandContext stuck the UI render progress.

## 相關問題 (Linked Issues)
<!--
- Related issues linked `fixes #number`
- Tests added. Pass Coverage.
- Errors have a helpful link.
-->
- Ui SelectInput Lag

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [ ] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS: Linux 5.15.133.1-microsoft-standard-WSL2 x86_64
* NodeJS Version:v18.18.2
* NPM Version:9.8.1
* Docker Version:24.0.7

## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [ ] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [ ] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [x] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [ ] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [x] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
