### PR TITLE
refactor: replace all then to promise

### DIFF
--- a/test/fabric/service/orderer.test.ts
+++ b/test/fabric/service/orderer.test.ts
@@ -32,27 +32,19 @@ describe('Orderer service:', function () {
       await minimumNetwork.deleteNetwork()
     })
 
-    it('should start and shutdown docker container', (done) => {
+    it('should start and shutdown docker container', async () => {
       const ordererHostname = `${minimumNetwork.getOrderer().hostname}.${minimumNetwork.getOrderer().orgDomain}`
       const port = minimumNetwork.getOrderer().port
 
-      ordererService.up({ ordererHostname }).then(() => {
-        const socket = net.connect(port, '127.0.0.1', () => {
-          ordererService.down({ ordererHostname })
-            .then(() => {
-              // TODO check container
-              done()
-            })
-            .catch((err) => {
-              assert.fail(`orderer down error: ${err.message}`)
-            })
+      await ordererService.up({ ordererHostname })
+      await new Promise<void>((resolve, reject) => {
+        const socket = net.connect(port, '127.0.0.1', async () => {
+          await ordererService.down({ ordererHostname })
+          resolve()
         })
-
         socket.on('error', (err) => {
-          assert.fail(`orderer connect test error: ${err.message}`)
+          reject(new Error(`orderer down error: ${err.message}`))
         })
-      }).catch((err) => {
-        assert.fail(`orderer up error: ${err.message}`)
       })
     })
   })

--- a/test/fabric/service/peer.test.ts
+++ b/test/fabric/service/peer.test.ts
@@ -34,27 +34,19 @@ describe('Peer service:', function () {
       await minimumNetwork.deleteNetwork()
     })
 
-    it('should start and shutdown docker container', (done) => {
+    it('should start and shutdown docker container', async () => {
       const peerHostname = `${minimumNetwork.getPeer().hostname}.${minimumNetwork.getPeer().orgDomain}`
       const port = minimumNetwork.getPeer().port
 
-      peerService.up({ peerHostname }).then(() => {
-        const socket = net.connect(port, '127.0.0.1', () => {
-          peerService.down({ peerHostname })
-            .then(() => {
-              // TODO check container
-              done()
-            })
-            .catch((err) => {
-              assert.fail(`peer down error: ${err.message}`)
-            })
+      await peerService.up({ peerHostname })
+      await new Promise<void>((resolve, reject) => {
+        const socket = net.connect(port, '127.0.0.1', async () => {
+          await peerService.down({ peerHostname })
+          resolve()
         })
-
-        socket.on('error', (err) => {
-          assert.fail(`peer connect test error: ${err.message}`)
+        socket.on('error', (err: any) => {
+          reject(new Error(`orderer down error: ${err.message}`))
         })
-      }).catch((err) => {
-        assert.fail(`peer up error: ${err.message}`)
       })
     })
   })


### PR DESCRIPTION
# PULL REQUEST

## Before 
<!-- Please check the one that applies to this PR using "x". -->
- [x] 遵守 Commit 規範 (follow [commit convention](https://github.com/cathayddt/bdk/blob/master/.github/COMMIT_CONVENTION.md))
- [x] 遵守 Contributing 規範 (follow [contributing](https://github.com/cathayddt/bdk/blob/master/.github/CONTRIBUTING.md))

## 說明 (Description)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!--請簡單說明此PR的更動、被修復的問題以及相關的原因，並請列出這個更動所需要的任何相依模組/套件。

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

as title, replace then in test case.

from `then...done()` to return a promise reject and resolve to solve the pattern.

## 相關問題 (Linked Issues)
<!--
- Related issues linked `fixes #number`
- Tests added. Pass Coverage.
- Errors have a helpful link.
-->
- no `then` in most case

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [ ] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS: macOS 14.2.1
* NodeJS Version: 9.8.1
* NPM Version: 18.18.2
* Docker Version: 24.0.6

## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [x] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [ ] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [x] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [ ] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [x] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
