### PR TITLE
fix: check node up

### DIFF
--- a/test/fabric/service/caService.test.ts
+++ b/test/fabric/service/caService.test.ts
@@ -388,12 +388,11 @@ describe('Fabric.CA', function () {
           reject(new Error(`rca connect test error: ${err.message}`))
         })
       })
-
-      after(async () => {
-        await caService.down({ caName: rcaArgv.basic.caName })
-        await caService.down({ caName: icaArgv.basic.caName })
-        fs.rmSync(`${config.infraConfig.bdkPath}/${config.networkName}`, { recursive: true })
-      })
+    })
+    after(async () => {
+      await caService.down({ caName: rcaArgv.basic.caName })
+      await caService.down({ caName: icaArgv.basic.caName })
+      fs.rmSync(`${config.infraConfig.bdkPath}/${config.networkName}`, { recursive: true })
     })
 
     it('reenroll orderer ca', async () => {


### PR DESCRIPTION
# PULL REQUEST

## Before 
<!-- Please check the one that applies to this PR using "x". -->
- [x] 遵守 Commit 規範 (follow [commit convention](https://github.com/cathayddt/bdk/blob/master/.github/COMMIT_CONVENTION.md))
- [x] 遵守 Contributing 規範 (follow [contributing](https://github.com/cathayddt/bdk/blob/master/.github/CONTRIBUTING.md))

## 說明 (Description)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

* fix channel create and orderer `nslookup` error in unit test
* my stupid fault in `test/fabric/service/caService.test.ts` just move the place

<!--請簡單說明此PR的更動、被修復的問題以及相關的原因，並請列出這個更動所需要的任何相依模組/套件。

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

## 相關問題 (Linked Issues)
<!--
- Related issues linked `fixes #number`
- Tests added. Pass Coverage.
- Errors have a helpful link.
-->
* update 2.1.0 github action error

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [ ] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS: 14.2.1
* NodeJS Version: 9.8.1
* NPM Version: 18.18.2
* Docker Version: 24.0.6

## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [x] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [x] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [ ] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [x] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [ ] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
