### PR TITLE
fix: network generate with networkInfo

### DIFF
--- a/src/quorum/service/network.ts
+++ b/src/quorum/service/network.ts
@@ -223,7 +223,7 @@ export default class Network extends AbstractService {
 
   public generate (networkGenerateConfig: NetworkGenerateType) {
     const staticNodesJson: string[] = []
-
+    const networkInfo: NetworkInfoItem[] = []
     // Add node to static-nodes.json
     for (let i = 0; i < networkGenerateConfig.validatorNumber; i += 1) {
       const { publicKey } = this.createKey(`artifacts/validator${i}`)
@@ -242,12 +242,15 @@ export default class Network extends AbstractService {
       this.bdkFile.copyPrivateKeyToValidator(i)
       this.bdkFile.copyPublicKeyToValidator(i)
       this.bdkFile.copyAddressToValidator(i)
+      this.createNetworkInfoJson(networkInfo, `http://validator${i}:${8545 + i * 2}`)
     }
     for (let i = 0; i < networkGenerateConfig.memberNumber; i += 1) {
       this.bdkFile.copyPrivateKeyToMember(i)
       this.bdkFile.copyPublicKeyToMember(i)
       this.bdkFile.copyAddressToMember(i)
+      this.createNetworkInfoJson(networkInfo, `http://member${i}:${8645 + i * 2}`)
     }
+    this.bdkFile.createNetworkInfoJson(networkInfo)
   }
 
   public async addValidatorLocal () {


### PR DESCRIPTION
# PULL REQUEST

## Before 
<!-- Please check the one that applies to this PR using "x". -->
- [x] 遵守 Commit 規範 (follow [commit convention](https://github.com/cathayddt/bdk/blob/master/.github/COMMIT_CONVENTION.md))
- [x] 遵守 Contributing 規範 (follow [contributing](https://github.com/cathayddt/bdk/blob/master/.github/CONTRIBUTING.md))

## 說明 (Description)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
`bdk quorum network join -i` Error with network-info.json
`error: ENOENT: no such file or directory, open '~/.bdk/quorum/bdk-quorum-network/network-info.json'`

<!--請簡單說明此PR的更動、被修復的問題以及相關的原因，並請列出這個更動所需要的任何相依模組/套件。

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

## 相關問題 (Linked Issues)
<!--
- Related issues linked `fixes #number`
- Tests added. Pass Coverage.
- Errors have a helpful link.
-->
#102 dashboard `network-info.json` not support join and generate flow

## 貢獻種類 (Type of change)

- [x] Bug fix (除錯 non-breaking change which fixes an issue)
- [ ] New feature (增加新功能 non-breaking change which adds functionality)
- [ ] Breaking change (可能導致相容性問題 fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc change (需要更新文件 this change requires a documentation update)

**測試環境 (Test Configuration)**:
* OS: 14.2.1
* NodeJS Version: 9.8.1
* NPM Version: 18.18.2
* Docker Version: 24.0.6

## 檢查清單 (Checklist):

- [x] 我的程式碼遵從此專案的規範 (My code follows the style guidelines of this project)
- [x] 我有對於自己的程式碼進行測試檢查 (I have performed a self-review of my own code)
- [ ] 我有在程式碼中提供必要的註解 (I have commented my code, particularly in hard-to-understand areas)
- [ ] 我有在文件中進行必要的更動 (I have made corresponding changes to the documentation)
- [x] 我的程式碼更動沒有顯著增加錯誤數量 (My changes generate no new warnings)
- [x] 我有新增必要的單元測試 (I have added tests that prove my fix is effective or that my feature works)
- [ ] 我有檢查並更正程式碼錯誤的拼字 (I have checked my code and corrected any misspellings)

我已完成以上清單，並且同意遵守 [Code of Conduct](CODE_OF_CONDUCT.md)

I have completed the checklist and agree to abide by the [code of conduct](CODE_OF_CONDUCT.md).

- [x] 同意 (I consent)
